### PR TITLE
Fix morpho useragent/cloudflare issue

### DIFF
--- a/.changeset/afraid-moons-greet.md
+++ b/.changeset/afraid-moons-greet.md
@@ -1,0 +1,5 @@
+---
+"@moonwell-fi/moonwell-sdk": patch
+---
+
+Fix morpho useragent/cloudflare issue

--- a/src/actions/core/markets/common.ts
+++ b/src/actions/core/markets/common.ts
@@ -7,6 +7,7 @@ import {
   perDay,
 } from "../../../common/index.js";
 
+import { MOONWELL_FETCH_JSON_HEADERS } from "../../../common/fetch-headers.js";
 import {
   type Environment,
   publicEnvironments,
@@ -241,6 +242,7 @@ const fetchFromGenericCacheApi = async <T>(uri: string): Promise<T> => {
     {
       method: "POST",
       body: `{"uri":"${uri}","cacheDuration":"300"}`,
+      headers: MOONWELL_FETCH_JSON_HEADERS,
     },
   );
 

--- a/src/actions/morpho/user-rewards/common.ts
+++ b/src/actions/morpho/user-rewards/common.ts
@@ -2,6 +2,7 @@ import lodash from "lodash";
 const { uniq } = lodash;
 import { type Address, getContract, parseAbi, zeroAddress } from "viem";
 import { Amount } from "../../../common/amount.js";
+import { MOONWELL_FETCH_JSON_HEADERS } from "../../../common/fetch-headers.js";
 import {
   type Environment,
   type TokenConfig,
@@ -384,6 +385,9 @@ async function getMorphoRewardsData(
 ): Promise<MorphoRewardsResponse[]> {
   const rewardsRequest = await fetch(
     `https://rewards.morpho.org/v1/users/${account}/rewards?chain_id=${chainId}`,
+    {
+      headers: MOONWELL_FETCH_JSON_HEADERS,
+    },
   );
   const rewards = await rewardsRequest.json();
   return (rewards.data || []) as MorphoRewardsResponse[];

--- a/src/actions/morpho/utils/graphql.ts
+++ b/src/actions/morpho/utils/graphql.ts
@@ -1,3 +1,4 @@
+import { MOONWELL_FETCH_JSON_HEADERS } from "../../../common/fetch-headers.js";
 import type { Environment } from "../../../environments/index.js";
 
 export async function getGraphQL<T>(
@@ -8,7 +9,7 @@ export async function getGraphQL<T>(
   try {
     const response = await fetch("https://blue-api.morpho.org/graphql", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: MOONWELL_FETCH_JSON_HEADERS,
       body: JSON.stringify({ query: query, operationName, variables }),
       signal: AbortSignal.timeout(10000),
     });
@@ -47,7 +48,7 @@ export async function getSubgraph<T>(
   try {
     const response = await fetch(url, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: MOONWELL_FETCH_JSON_HEADERS,
       body: JSON.stringify(body),
       signal: AbortSignal.timeout(10000),
     });

--- a/src/common/fetch-headers.ts
+++ b/src/common/fetch-headers.ts
@@ -1,0 +1,16 @@
+// Try to get the version from package.json, fallback to '1.0.0'
+let sdkVersion = "1.0.0";
+try {
+  // @ts-ignore
+  sdkVersion =
+    (await import("../../package.json", { assert: { type: "json" } })).default
+      .version || "1.0.0";
+} catch (e) {
+  // fallback to default
+}
+
+export const MOONWELL_FETCH_JSON_HEADERS: Record<string, string> = {
+  Accept: "application/json",
+  "Content-Type": "application/json",
+  "User-Agent": `moonwell-sdk/${sdkVersion}`,
+};


### PR DESCRIPTION
I observed an issue where using the moonwell-sdk in a Cloudflare worker resulted in failures. This was due to Morpho API blocking all Cloudflare workers from directly pinging it.

To resolve this, I’ve modified all `fetch` requests to consistently use a default `moonwell/${VERSION}` UserAgent.