### PR TITLE
Only add user agent in node js

### DIFF
--- a/.changeset/polite-pumpkins-speak.md
+++ b/.changeset/polite-pumpkins-speak.md
@@ -1,0 +1,5 @@
+---
+"@moonwell-fi/moonwell-sdk": patch
+---
+
+Include User-Agent for only non-browser environment

--- a/src/common/fetch-headers.ts
+++ b/src/common/fetch-headers.ts
@@ -9,8 +9,11 @@ try {
   // fallback to default
 }
 
+const isBrowser =
+  typeof window !== "undefined" && typeof window.document !== "undefined";
+
 export const MOONWELL_FETCH_JSON_HEADERS: Record<string, string> = {
   Accept: "application/json",
   "Content-Type": "application/json",
-  "User-Agent": `moonwell-sdk/${sdkVersion}`,
+  ...(isBrowser ? {} : { "User-Agent": `moonwell-sdk/${sdkVersion}` }),
 };


### PR DESCRIPTION
This pull request introduces a change to the `MOONWELL_FETCH_JSON_HEADERS` constant in `src/common/fetch-headers.ts` to conditionally exclude the `User-Agent` header in browser environments.

Key change:

* Added an `isBrowser` check to determine the runtime environment. The `User-Agent` header is now included only in non-browser environments to avoid issues with browsers that disallow setting this header. (`[src/common/fetch-headers.tsR12-R18](diffhunk://#diff-baba4c3028ed44faa6335607df8b129437cc5c131f67b5ed7e5062891ccd8845R12-R18)`)