### PR TITLE
docs(changeset): When one or more networks' RPC nodes are down, the S…

### DIFF
--- a/.changeset/healthy-lizards-attend.md
+++ b/.changeset/healthy-lizards-attend.md
@@ -1,0 +1,5 @@
+---
+"@moonwell-fi/moonwell-sdk": minor
+---
+
+When one or more networks' RPC nodes are down, the SDK will still return responses from available RPC nodes to consumers.


### PR DESCRIPTION
…DK will still return responses from available RPC nodes to consumers.