### PR TITLE
fix: treat borrowIncentivesPerSec=1 as zero for all tokens

### DIFF
--- a/src/actions/core/markets/common.ts
+++ b/src/actions/core/markets/common.ts
@@ -236,9 +236,10 @@ export const getMarketsData = async (environment: Environment) => {
               : tokenPrice;
 
           if (price) {
-            // USDC on-chain returns borrowIncentivesPerSec=1 (1 wei) as a
-            // placeholder when there are no active borrow incentives. Treat as zero.
-            if (token.symbol === "USDC" && borrowIncentivesPerSec === 1n) {
+            // On-chain contracts use borrowIncentivesPerSec=1 (1 wei) as a
+            // placeholder when there are no active borrow incentives, because
+            // setting it to 0 triggers a known smart contract bug. Treat as zero.
+            if (borrowIncentivesPerSec === 1n) {
               borrowIncentivesPerSec = 0n;
             }
 
@@ -634,13 +635,19 @@ async function fetchMarketsFromLunar(
       let supplyApr: number;
       let borrowApr: number;
 
+      // On-chain contracts use borrowIncentivesPerSec=1 (1 wei) as a
+      // placeholder when there are no active borrow incentives, because
+      // setting it to 0 triggers a known smart contract bug. Treat as zero.
+      const isBorrowPlaceholder =
+        BigInt(incentive.borrowIncentivesPerSec) === 1n;
+
       if (
         incentive.priceUsd !== null &&
         incentive.supplyApr !== null &&
         incentive.borrowApr !== null
       ) {
         supplyApr = Number(incentive.supplyApr);
-        borrowApr = -Number(incentive.borrowApr);
+        borrowApr = isBorrowPlaceholder ? 0 : -Number(incentive.borrowApr);
       } else {
         const isGovernanceToken =
           token.symbol === environment.custom?.governance?.token;
@@ -656,14 +663,10 @@ async function fetchMarketsFromLunar(
           continue;
         }
 
-        let borrowIncentivesPerSec = BigInt(incentive.borrowIncentivesPerSec);
+        const borrowIncentivesPerSec = isBorrowPlaceholder
+          ? 0n
+          : BigInt(incentive.borrowIncentivesPerSec);
         const supplyIncentivesPerSec = BigInt(incentive.supplyIncentivesPerSec);
-
-        // USDC on-chain returns borrowIncentivesPerSec=1 (1 wei) as a
-        // placeholder when there are no active borrow incentives. Treat as zero.
-        if (token.symbol === "USDC" && borrowIncentivesPerSec === 1n) {
-          borrowIncentivesPerSec = 0n;
-        }
 
         const supplyRewardsPerDayUsd =
           perDay(new Amount(supplyIncentivesPerSec, token.decimals).value) *

--- a/src/package.json
+++ b/src/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@moonwell-fi/moonwell-sdk",
   "description": "TypeScript Interface for Moonwell",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "type": "module",
   "main": "./_cjs/index.js",
   "module": "./_esm/index.js",


### PR DESCRIPTION
## Summary

- Fixes inflated borrow APY display on markets like VVV (~4600% instead of 0%)
- The existing `borrowIncentivesPerSec === 1n` check only applied to USDC in the on-chain code path, missing both the Lunar indexer path (which returns pre-computed inflated APRs) and non-USDC tokens
- Now applies the placeholder check globally across all three code paths (on-chain, Lunar pre-computed, and Lunar fallback) for any token
- Bumps version to 0.10.5

## Context

On-chain contracts use `borrowIncentivesPerSec=1` (1 wei) as a placeholder when there are no active borrow incentives, because setting it to 0 triggers a known smart contract bug. The Lunar indexer computes a large APR from this 1-wei placeholder divided by a tiny total borrows value ($0.09 for VVV), resulting in ~4600% borrow APY.

## Test plan

- [ ] Verify VVV market on Base no longer shows inflated borrow APY
- [ ] Verify other markets with legitimate borrow rewards are unaffected
- [ ] Verify the fix applies to both Lunar and on-chain code paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)