### PR TITLE
Fix v2 vaults tvl

### DIFF
--- a/.changeset/cuddly-carpets-yell.md
+++ b/.changeset/cuddly-carpets-yell.md
@@ -1,0 +1,5 @@
+---
+"@moonwell-fi/moonwell-sdk": patch
+---
+
+For V2 vaults, substitute TVL from the paired V1 vault and use V1 snapshots

--- a/src/actions/morpho/vaults/common.ts
+++ b/src/actions/morpho/vaults/common.ts
@@ -179,6 +179,25 @@ async function getMorphoVaultsDataFromIndexer(params: {
           tokenMap,
         );
 
+        // For V2 vaults, substitute TVL from the paired V1 vault.
+        // V2 routes deposits through V1 via a liquidity adapter, so V1 holds
+        // the actual assets — the Morpho API returns only V2's idle assets (~$13).
+        // APY and rewards are kept from V2's own indexer data.
+        const vaultByKey = new Map(vaults.map((v) => [v.vaultKey, v]));
+        for (const vault of vaults) {
+          const v1VaultKey = environment.config.vaults[vault.vaultKey]
+            ?.v1VaultKey as string | undefined;
+          if (!v1VaultKey) continue;
+          const v1Vault = vaultByKey.get(v1VaultKey);
+          if (!v1Vault) continue;
+          vault.totalSupply = v1Vault.totalSupply;
+          vault.totalSupplyUsd = v1Vault.totalSupplyUsd;
+          vault.vaultSupply = v1Vault.vaultSupply;
+          vault.totalLiquidity = v1Vault.totalLiquidity;
+          vault.totalLiquidityUsd = v1Vault.totalLiquidityUsd;
+          vault.underlyingPrice = v1Vault.underlyingPrice;
+        }
+
         // Filter by specific vault addresses if requested
         if (params.vaults) {
           const requestedVaults = params.vaults.map((id) => id.toLowerCase());

--- a/src/actions/morpho/vaults/common.ts
+++ b/src/actions/morpho/vaults/common.ts
@@ -184,19 +184,28 @@ async function getMorphoVaultsDataFromIndexer(params: {
         // the actual assets — the Morpho API returns only V2's idle assets (~$13).
         // APY and rewards are kept from V2's own indexer data.
         const vaultByKey = new Map(vaults.map((v) => [v.vaultKey, v]));
-        for (const vault of vaults) {
-          const v1VaultKey = environment.config.vaults[vault.vaultKey]
-            ?.v1VaultKey as string | undefined;
-          if (!v1VaultKey) continue;
+        vaults = vaults.map((vault) => {
+          const rawKey = environment.config.vaults[vault.vaultKey]?.v1VaultKey;
+          const v1VaultKey = typeof rawKey === "string" ? rawKey : undefined;
+
+          if (!v1VaultKey) return vault;
+
           const v1Vault = vaultByKey.get(v1VaultKey);
-          if (!v1Vault) continue;
-          vault.totalSupply = v1Vault.totalSupply;
-          vault.totalSupplyUsd = v1Vault.totalSupplyUsd;
-          vault.vaultSupply = v1Vault.vaultSupply;
-          vault.totalLiquidity = v1Vault.totalLiquidity;
-          vault.totalLiquidityUsd = v1Vault.totalLiquidityUsd;
-          vault.underlyingPrice = v1Vault.underlyingPrice;
-        }
+
+          if (!v1Vault) {
+            return vault;
+          }
+
+          return {
+            ...vault,
+            totalSupply: v1Vault.totalSupply,
+            totalSupplyUsd: v1Vault.totalSupplyUsd,
+            vaultSupply: v1Vault.vaultSupply,
+            totalLiquidity: v1Vault.totalLiquidity,
+            totalLiquidityUsd: v1Vault.totalLiquidityUsd,
+            underlyingPrice: v1Vault.underlyingPrice,
+          };
+        });
 
         // Filter by specific vault addresses if requested
         if (params.vaults) {
@@ -474,8 +483,8 @@ async function getMorphoVaultsDataFromOnChain(params: {
         .filter((address) =>
           params.vaults
             ? params.vaults
-                .map((id) => id.toLowerCase())
-                .includes(address.toLowerCase())
+              .map((id) => id.toLowerCase())
+              .includes(address.toLowerCase())
             : true,
         );
 
@@ -486,31 +495,31 @@ async function getMorphoVaultsDataFromOnChain(params: {
         .filter((address) =>
           params.vaults
             ? params.vaults
-                .map((id) => id.toLowerCase())
-                .includes(address.toLowerCase())
+              .map((id) => id.toLowerCase())
+              .includes(address.toLowerCase())
             : true,
         );
 
       // Run v1 and v2 queries in parallel within this environment
       const queryPromises: Promise<
         | readonly {
-            vault: `0x${string}`;
-            totalSupply: bigint;
-            totalAssets: bigint;
-            underlyingPrice: bigint;
-            fee: bigint;
-            timelock: bigint;
-            markets: readonly {
-              marketId: `0x${string}`;
-              marketCollateral: `0x${string}`;
-              marketCollateralName: string;
-              marketCollateralSymbol: string;
-              marketLltv: bigint;
-              marketApy: bigint;
-              marketLiquidity: bigint;
-              vaultSupplied: bigint;
-            }[];
-          }[]
+          vault: `0x${string}`;
+          totalSupply: bigint;
+          totalAssets: bigint;
+          underlyingPrice: bigint;
+          fee: bigint;
+          timelock: bigint;
+          markets: readonly {
+            marketId: `0x${string}`;
+            marketCollateral: `0x${string}`;
+            marketCollateralName: string;
+            marketCollateralSymbol: string;
+            marketLltv: bigint;
+            marketApy: bigint;
+            marketLiquidity: bigint;
+            vaultSupplied: bigint;
+          }[];
+        }[]
         | undefined
       >[] = [];
 
@@ -1510,7 +1519,7 @@ export async function getMorphoVaultsRewards(
             .filter(
               (reward) =>
                 reward.vaultId.toLowerCase() ===
-                  vault.vaultToken.address.toLowerCase() &&
+                vault.vaultToken.address.toLowerCase() &&
                 (reward.chainId === vault.chainId || !currentChainRewardsOnly),
             )
             .map((reward) => {

--- a/src/actions/morpho/vaults/common.ts
+++ b/src/actions/morpho/vaults/common.ts
@@ -30,6 +30,7 @@ import {
 import {
   fetchTokenMap,
   fetchVaultsFromIndexer,
+  getV1VaultKey,
   transformVaultsFromIndexer,
 } from "./lunarIndexerTransform.js";
 
@@ -185,17 +186,12 @@ async function getMorphoVaultsDataFromIndexer(params: {
         // APY and rewards are kept from V2's own indexer data.
         const vaultByKey = new Map(vaults.map((v) => [v.vaultKey, v]));
         vaults = vaults.map((vault) => {
-          const rawKey = environment.config.vaults[vault.vaultKey]?.v1VaultKey;
-          const v1VaultKey = typeof rawKey === "string" ? rawKey : undefined;
-
+          const v1VaultKey = getV1VaultKey(environment, vault.vaultKey);
           if (!v1VaultKey) return vault;
-
           const v1Vault = vaultByKey.get(v1VaultKey);
-
           if (!v1Vault) {
             return vault;
           }
-
           return {
             ...vault,
             totalSupply: v1Vault.totalSupply,
@@ -994,9 +990,35 @@ async function getMorphoVaultsDataFromOnChain(params: {
         ),
       );
 
-      const vaults = settled.flatMap((s) =>
+      let vaults = settled.flatMap((s) =>
         s.status === "fulfilled" ? s.value : [],
       );
+
+      // For V2 vaults, substitute TVL from the paired V1 vault (same as indexer path).
+      // V2 routes deposits through V1 via a liquidity adapter, so V1 holds the actual
+      // assets — on-chain data returns only V2's idle assets.
+      const onChainVaultByKey = new Map(vaults.map((v) => [v.vaultKey, v]));
+
+      vaults = vaults.map((vault) => {
+        const v1VaultKey = getV1VaultKey(environment, vault.vaultKey);
+        if (!v1VaultKey) return vault;
+
+        const v1Vault = onChainVaultByKey.get(v1VaultKey);
+
+        if (!v1Vault) {
+          return vault;
+        }
+
+        return {
+          ...vault,
+          totalSupply: v1Vault.totalSupply,
+          totalSupplyUsd: v1Vault.totalSupplyUsd,
+          vaultSupply: v1Vault.vaultSupply,
+          totalLiquidity: v1Vault.totalLiquidity,
+          totalLiquidityUsd: v1Vault.totalLiquidityUsd,
+          underlyingPrice: v1Vault.underlyingPrice,
+        };
+      });
 
       return {
         ...(await aggregator),

--- a/src/actions/morpho/vaults/getMorphoVaultSnapshots.ts
+++ b/src/actions/morpho/vaults/getMorphoVaultSnapshots.ts
@@ -15,6 +15,7 @@ import type { Chain, Environment } from "../../../environments/index.js";
 import type { MorphoVaultSnapshot } from "../../../types/morphoVault.js";
 import {
   fetchVaultSnapshotsFromIndexer,
+  getV1VaultKey,
   transformVaultSnapshotsFromIndexer,
 } from "./lunarIndexerTransform.js";
 
@@ -43,8 +44,8 @@ export async function getMorphoVaultSnapshots<
     return [];
   }
 
-  let {
-    vaultAddress,
+  const {
+    vaultAddress: requestedVaultAddress,
     period,
     startTime: customStartTime,
     endTime: customEndTime,
@@ -52,38 +53,51 @@ export async function getMorphoVaultSnapshots<
 
   // For V2 vaults, fetch snapshots using the paired V1 address.
   // Historical snapshots are indexed against V1 since that is where assets are held.
-  let v1VaultKey: string | undefined;
+  // The original (V2) address is preserved so that returned snapshots carry the
+  // address the caller requested, not the internal V1 address used for fetching.
+  let fetchAddress = requestedVaultAddress;
 
-  for (const [vaultKey, vaultConfig] of Object.entries(environment.config.vaults)) {
-    const tokenAddress = environment.config.tokens[vaultKey]?.address;
+  const matchedEntry = Object.entries(environment.config.vaults).find(
+    ([, vaultConfig]) =>
+      environment.config.tokens[vaultConfig.vaultToken as string]?.address?.toLowerCase() ===
+      requestedVaultAddress.toLowerCase(),
+  );
 
-    if (tokenAddress?.toLowerCase() === vaultAddress.toLowerCase()) {
-      const rawKey = vaultConfig.v1VaultKey;
-      v1VaultKey = typeof rawKey === "string" ? rawKey : undefined;
-      break;
-    }
-  }
-  if (v1VaultKey) {
-    const v1Token = environment.config.tokens[v1VaultKey];
-    if (v1Token?.address) {
-      vaultAddress = v1Token.address;
+  if (matchedEntry !== undefined) {
+    const [matchedVaultKey] = matchedEntry;
+    const v1VaultKey = getV1VaultKey(environment, matchedVaultKey);
+
+    if (v1VaultKey) {
+      const v1Token = environment.config.tokens[v1VaultKey];
+      if (v1Token?.address) {
+        fetchAddress = v1Token.address;
+      }
     }
   }
 
   const lunarIndexerUrl = environment.custom?.morpho?.lunarIndexerUrl;
 
-  if (lunarIndexerUrl) {
-    return fetchVaultSnapshotsFromLunarIndexer(
-      vaultAddress,
+  const snapshots = lunarIndexerUrl
+    ? await fetchVaultSnapshotsFromLunarIndexer(
+      fetchAddress,
       environment.chainId,
       lunarIndexerUrl,
       period,
       customStartTime,
       customEndTime,
-    );
+    )
+    : await fetchVaultSnapshotsFromPonder(fetchAddress, environment);
+
+  // Restore the originally-requested vault address on every snapshot so
+  // callers keying by address see the V2 address they asked for.
+  if (fetchAddress.toLowerCase() !== requestedVaultAddress.toLowerCase()) {
+    return snapshots.map((s) => ({
+      ...s,
+      vaultAddress: requestedVaultAddress.toLowerCase(),
+    }));
   }
 
-  return fetchVaultSnapshotsFromPonder(vaultAddress, environment);
+  return snapshots;
 }
 
 async function fetchVaultSnapshotsFromLunarIndexer(

--- a/src/actions/morpho/vaults/getMorphoVaultSnapshots.ts
+++ b/src/actions/morpho/vaults/getMorphoVaultSnapshots.ts
@@ -52,14 +52,17 @@ export async function getMorphoVaultSnapshots<
 
   // For V2 vaults, fetch snapshots using the paired V1 address.
   // Historical snapshots are indexed against V1 since that is where assets are held.
-  const vaultConfigKey = Object.keys(environment.config.vaults).find(
-    (key) =>
-      environment.config.tokens[key]?.address?.toLowerCase() ===
-      vaultAddress.toLowerCase(),
-  );
-  const v1VaultKey = vaultConfigKey
-    ? (environment.config.vaults[vaultConfigKey]?.v1VaultKey as string | undefined)
-    : undefined;
+  let v1VaultKey: string | undefined;
+
+  for (const [vaultKey, vaultConfig] of Object.entries(environment.config.vaults)) {
+    const tokenAddress = environment.config.tokens[vaultKey]?.address;
+
+    if (tokenAddress?.toLowerCase() === vaultAddress.toLowerCase()) {
+      const rawKey = vaultConfig.v1VaultKey;
+      v1VaultKey = typeof rawKey === "string" ? rawKey : undefined;
+      break;
+    }
+  }
   if (v1VaultKey) {
     const v1Token = environment.config.tokens[v1VaultKey];
     if (v1Token?.address) {

--- a/src/actions/morpho/vaults/getMorphoVaultSnapshots.ts
+++ b/src/actions/morpho/vaults/getMorphoVaultSnapshots.ts
@@ -43,12 +43,29 @@ export async function getMorphoVaultSnapshots<
     return [];
   }
 
-  const {
+  let {
     vaultAddress,
     period,
     startTime: customStartTime,
     endTime: customEndTime,
   } = args as GetMorphoVaultSnapshotsParameters<environments, undefined>;
+
+  // For V2 vaults, fetch snapshots using the paired V1 address.
+  // Historical snapshots are indexed against V1 since that is where assets are held.
+  const vaultConfigKey = Object.keys(environment.config.vaults).find(
+    (key) =>
+      environment.config.tokens[key]?.address?.toLowerCase() ===
+      vaultAddress.toLowerCase(),
+  );
+  const v1VaultKey = vaultConfigKey
+    ? (environment.config.vaults[vaultConfigKey]?.v1VaultKey as string | undefined)
+    : undefined;
+  if (v1VaultKey) {
+    const v1Token = environment.config.tokens[v1VaultKey];
+    if (v1Token?.address) {
+      vaultAddress = v1Token.address;
+    }
+  }
 
   const lunarIndexerUrl = environment.custom?.morpho?.lunarIndexerUrl;
 

--- a/src/actions/morpho/vaults/lunarIndexerTransform.test.ts
+++ b/src/actions/morpho/vaults/lunarIndexerTransform.test.ts
@@ -1,15 +1,19 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { Amount } from "../../../common/amount.js";
+import type { MoonwellClient } from "../../../client/createMoonwellClient.js";
 import { createEnvironment as createBaseEnvironment } from "../../../environments/definitions/base/environment.js";
 import {
   fetchTokenMap,
   fetchVaultFromIndexer,
   fetchVaultSnapshotsFromIndexer,
   fetchVaultsFromIndexer,
+  getV1VaultKey,
   transformVaultFromIndexer,
   transformVaultSnapshotsFromIndexer,
   transformVaultsFromIndexer,
 } from "./lunarIndexerTransform.js";
+import { getMorphoVaultsData } from "./common.js";
+import { getMorphoVaultSnapshots } from "./getMorphoVaultSnapshots.js";
 
 // ─── Fixtures ────────────────────────────────────────────────────────────────
 
@@ -987,5 +991,166 @@ describe("Lunar Indexer Transformation Tests", () => {
     expect(typeof snap.totalLiquidity).toBe("number");
     expect(typeof snap.totalLiquidityUsd).toBe("number");
     expect(typeof snap.timestamp).toBe("number");
+  });
+});
+
+// ─── getV1VaultKey unit tests ─────────────────────────────────────────────────
+
+describe("getV1VaultKey", () => {
+  test("returns v1VaultKey for a V2 vault", () => {
+    const env = createBaseEnvironment();
+    expect(getV1VaultKey(env, "meUSDC")).toBe("meUSDCv1");
+    expect(getV1VaultKey(env, "mwUSDC")).toBe("mwUSDCv1");
+    expect(getV1VaultKey(env, "mwETH")).toBe("mwETHv1");
+  });
+
+  test("returns undefined for a V1 vault", () => {
+    const env = createBaseEnvironment();
+    expect(getV1VaultKey(env, "meUSDCv1")).toBeUndefined();
+    expect(getV1VaultKey(env, "mwUSDCv1")).toBeUndefined();
+    expect(getV1VaultKey(env, "mwETHv1")).toBeUndefined();
+  });
+
+  test("returns undefined for an unknown vault key", () => {
+    const env = createBaseEnvironment();
+    expect(getV1VaultKey(env, "doesNotExist")).toBeUndefined();
+  });
+});
+
+// ─── V2 vault TVL substitution tests ─────────────────────────────────────────
+
+// V2 vault token address (meUSDC) and its paired V1 (meUSDCv1)
+const MEUSDC_V2_ADDRESS = "0xbb2f06ceae42cbcf5559ed0713538c8892d977c9";
+const MEUSDC_V1_ADDRESS = "0xe1ba476304255353aef290e6474a417d06e7b773";
+
+describe("V2 vault TVL substitution (indexer path)", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", createMockFetch());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("V2 vault TVL fields are substituted from paired V1 vault", async () => {
+    const environment = createBaseEnvironment(undefined, undefined, undefined, LUNAR_INDEXER_URL);
+    const vaults = await getMorphoVaultsData({ environments: [environment] });
+
+    const meUSDC = vaults.find((v) => v.vaultKey === "meUSDC");
+    const meUSDCv1 = vaults.find((v) => v.vaultKey === "meUSDCv1");
+
+    expect(meUSDC).toBeDefined();
+    expect(meUSDCv1).toBeDefined();
+
+    // TVL should be taken from V1
+    expect(meUSDC!.totalSupplyUsd).toBeCloseTo(meUSDCv1!.totalSupplyUsd, 0);
+    expect(meUSDC!.totalLiquidityUsd).toBeCloseTo(meUSDCv1!.totalLiquidityUsd, 0);
+    expect(meUSDC!.totalSupply.value).toBeCloseTo(meUSDCv1!.totalSupply.value, 4);
+    expect(meUSDC!.totalLiquidity.value).toBeCloseTo(meUSDCv1!.totalLiquidity.value, 4);
+    expect(meUSDC!.underlyingPrice).toBeCloseTo(meUSDCv1!.underlyingPrice, 4);
+  });
+
+  test("V2 vault APY and rewards are NOT substituted from V1", async () => {
+    const environment = createBaseEnvironment(undefined, undefined, undefined, LUNAR_INDEXER_URL);
+    const vaults = await getMorphoVaultsData({ environments: [environment] });
+
+    const meUSDC = vaults.find((v) => v.vaultKey === "meUSDC");
+
+    // APY/rewards come from V2's own indexer data (MOCK_MEUSDC_VAULT values)
+    expect(meUSDC!.baseApy).toBeCloseTo(Number.parseFloat(MOCK_MEUSDC_VAULT.baseApy), 6);
+    expect(meUSDC!.rewardsApy).toBeCloseTo(Number.parseFloat(MOCK_MEUSDC_VAULT.rewardsApy), 6);
+    expect(meUSDC!.totalApy).toBeCloseTo(Number.parseFloat(MOCK_MEUSDC_VAULT.totalApy), 6);
+  });
+
+  test("V1 vaults are not affected by the substitution", async () => {
+    const environment = createBaseEnvironment(undefined, undefined, undefined, LUNAR_INDEXER_URL);
+    const vaults = await getMorphoVaultsData({ environments: [environment] });
+
+    const meUSDCv1 = vaults.find((v) => v.vaultKey === "meUSDCv1");
+
+    expect(meUSDCv1!.totalSupplyUsd).toBeCloseTo(
+      Number.parseFloat(MOCK_MEUSDCV1_VAULT.totalAssetsUsd),
+      0,
+    );
+    expect(meUSDCv1!.totalLiquidityUsd).toBeCloseTo(
+      Number.parseFloat(MOCK_MEUSDCV1_VAULT.totalLiquidityUsd),
+      0,
+    );
+  });
+
+  test("V2 vault returns original data when V1 vault is missing from results", async () => {
+    // Mock fetch that omits meUSDCv1 from the vault list
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string) => {
+        if (url.includes("/api/v1/vaults/tokens/")) {
+          return makeJsonResponse({ results: MOCK_TOKENS, nextCursor: null });
+        }
+        if (url.includes("/api/v1/vaults/vaults/")) {
+          // Return only V2 vault, no V1 pair
+          return makeJsonResponse({
+            results: [MOCK_MEUSDC_VAULT],
+            nextCursor: null,
+          });
+        }
+        return Promise.reject(new Error(`Unmocked URL: ${url}`));
+      }),
+    );
+
+    const environment = createBaseEnvironment(undefined, undefined, undefined, LUNAR_INDEXER_URL);
+    const vaults = await getMorphoVaultsData({ environments: [environment] });
+
+    const meUSDC = vaults.find((v) => v.vaultKey === "meUSDC");
+    expect(meUSDC).toBeDefined();
+    // Should retain its own TVL since V1 was not found
+    expect(meUSDC!.totalSupplyUsd).toBeCloseTo(
+      Number.parseFloat(MOCK_MEUSDC_VAULT.totalAssetsUsd),
+      0,
+    );
+  });
+});
+
+// ─── Snapshot address redirect tests ─────────────────────────────────────────
+
+describe("getMorphoVaultSnapshots V2 address redirect", () => {
+  // Build a minimal mock client backed by the base environment with lunarIndexerUrl
+  const mockClient = {
+    environments: {
+      base: createBaseEnvironment(undefined, undefined, undefined, LUNAR_INDEXER_URL),
+    },
+  } as unknown as MoonwellClient;
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", createMockFetch());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("snapshots requested for a V2 vault are returned with the V2 address", async () => {
+    const snapshots = await getMorphoVaultSnapshots(mockClient, {
+      chainId: BASE_CHAIN_ID,
+      vaultAddress: MEUSDC_V2_ADDRESS,
+    });
+
+    expect(snapshots.length).toBeGreaterThan(0);
+    // All snapshots must carry the V2 address the caller passed, not the V1 fetch address
+    for (const snap of snapshots) {
+      expect(snap.vaultAddress).toBe(MEUSDC_V2_ADDRESS.toLowerCase());
+    }
+  });
+
+  test("snapshots requested for a V1 vault are returned without any address rewrite", async () => {
+    const snapshots = await getMorphoVaultSnapshots(mockClient, {
+      chainId: BASE_CHAIN_ID,
+      vaultAddress: MEUSDC_V1_ADDRESS,
+    });
+
+    expect(snapshots.length).toBeGreaterThan(0);
+    // V1 vault: no redirect occurs, so snapshot addresses come through as-is from the indexer
+    for (const snap of snapshots) {
+      expect(snap.vaultAddress).toBe(MOCK_VAULT_SNAPSHOT_1.vaultAddress.toLowerCase());
+    }
   });
 });

--- a/src/actions/morpho/vaults/lunarIndexerTransform.ts
+++ b/src/actions/morpho/vaults/lunarIndexerTransform.ts
@@ -482,6 +482,18 @@ export async function fetchVaultSnapshotsFromIndexer(
  * @param chainId - Chain ID for the snapshots
  * @returns Array of transformed MorphoVaultSnapshot objects
  */
+/**
+ * Returns the V1 vault key paired with a given vault, or undefined if the vault
+ * has no V1 pair (i.e. it is already a V1 vault or has no v1VaultKey configured).
+ */
+export function getV1VaultKey(
+  environment: Environment,
+  vaultKey: string,
+): string | undefined {
+  const rawKey = environment.config.vaults[vaultKey]?.v1VaultKey;
+  return typeof rawKey === "string" ? rawKey : undefined;
+}
+
 export function transformVaultSnapshotsFromIndexer(
   snapshots: LunarIndexerVaultSnapshot[],
   chainId: number,

--- a/src/environments/definitions/base/morpho-vaults.ts
+++ b/src/environments/definitions/base/morpho-vaults.ts
@@ -10,6 +10,7 @@ export const vaults = createVaultConfig({
       campaignId:
         "0x1df9a935f6b928b4809c4fda483f16839140864b2b412cc5fea85fd5d9d00e57",
       version: 2,
+      v1VaultKey: "mwETHv1",
     },
     mwETHv1: {
       underlyingToken: "ETH",
@@ -23,6 +24,7 @@ export const vaults = createVaultConfig({
       campaignId:
         "0xec43a3d75ae25c5255eb06b3aac6b79ccb2cdb6b99740ea13553661b0f06b756",
       version: 2,
+      v1VaultKey: "mwUSDCv1",
     },
     mwUSDCv1: {
       underlyingToken: "USDC",
@@ -36,6 +38,7 @@ export const vaults = createVaultConfig({
       campaignId:
         "0x03430078e052d58b6e80fa8e373c38a75736f1d24768b9c92a2e44bc4ce62b1d",
       version: 2,
+      v1VaultKey: "mwEURCv1",
     },
     mwEURCv1: {
       underlyingToken: "EURC",
@@ -49,6 +52,7 @@ export const vaults = createVaultConfig({
       campaignId:
         "0xb230a09331c22280ae3e02a65caad21a553274912352d8f93c7a92c0f9bb3da4",
       version: 2,
+      v1VaultKey: "mwcbBTCv1",
     },
     mwcbBTCv1: {
       underlyingToken: "cbBTC",
@@ -62,6 +66,7 @@ export const vaults = createVaultConfig({
       campaignId:
         "0x6738320fdf80785ff7a1d45ed93a6ffa07068ce9ec4170c1887d09f32fba7b57",
       version: 2,
+      v1VaultKey: "meUSDCv1",
     },
     meUSDCv1: {
       underlyingToken: "USDC",

--- a/src/environments/types/config.ts
+++ b/src/environments/types/config.ts
@@ -73,6 +73,7 @@ export type VaultConfig<tokens> = {
   multiReward?: Address;
   version?: 1 | 2; // 1 = MetaMorpho V1, 2 = Morpho Vault V2
   deprecated?: boolean;
+  v1VaultKey?: keyof tokens; // For V2 vaults: the key of the paired V1 liquidity adapter vault
 };
 
 export type MarketConfig<tokens> = {

--- a/src/package.json
+++ b/src/package.json
@@ -49,7 +49,10 @@
   },
   "typesVersions": {
     "*": {
-      "actions": ["./_types/actions/index.d.ts"]
+      "actions": ["./_types/actions/index.d.ts"],
+      "client": ["./_types/client/index.d.ts"],
+      "common": ["./_types/common/index.d.ts"],
+      "environments": ["./_types/environments/index.d.ts"]
     }
   },
   "peerDependencies": {


### PR DESCRIPTION
## Fix Morpho V2 vault TVL and historical snapshots                                                                                                                                                                                            
                                                                                                                                                                                                                                               
  Morpho V2 vaults route deposits through a V1 liquidity adapter, so the Morpho API returns only V2's idle assets instead of the actual TVL. APY and rewards are correctly sourced from the indexer.
                                                                                                                                                                                                                                                 
  ### Changes                                                                                                                                                                                                                                    
  - Add `v1VaultKey` to `VaultConfig` to link each V2 vault to its paired V1 vault                                                                                                                                                               
  - Substitute V2 TVL fields (`totalSupply`, `totalLiquidity`, `underlyingPrice`) with V1 data
  - Fetch historical snapshots using the V1 vault address (snapshots are indexed against V1)
  - APY and rewards remain unchanged, using V2's own indexer data