### PR TITLE
add husky pre-commit hook for breaking change detection

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+npx lint-staged
+bun scripts/checkBreakingChanges.ts

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test": "vitest -c ./test/vitest.config.ts dev",
     "preinstall": "pnpx only-allow pnpm",
     "postinstall": "git submodule update --init --recursive",
+    "prepare": "husky",
     "deps": "pnpx taze -r",
     "preconstruct": "bun scripts/preconstruct.ts",
     "changeset:prepublish": "pnpm version:update && bun scripts/prepublishOnly.ts && pnpm build",
@@ -35,13 +36,13 @@
     "@changesets/cli": "^2.27.9",
     "bun": "^1.1.12",
     "dayjs": "^1.11.13",
+    "husky": "^9.1.7",
     "jsdom": "^25.0.1",
     "knip": "^5.33.3",
     "lint-staged": "^15.1.0",
     "prool": "^0.0.16",
     "publint": "^0.2.11",
     "sherif": "^1.0.0",
-    "simple-git-hooks": "^2.9.0",
     "typescript": "5.9.3",
     "vitest": "^2.1.2"
   },
@@ -51,9 +52,6 @@
       "biome check --no-errors-on-unmatched"
     ],
     "!(*.ts)": ["biome format --no-errors-on-unmatched --write"]
-  },
-  "simple-git-hooks": {
-    "pre-commit": "npx lint-staged"
   },
   "packageManager": "pnpm@9.1.0",
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       dayjs:
         specifier: ^1.11.13
         version: 1.11.13
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
       jsdom:
         specifier: ^25.0.1
         version: 25.0.1
@@ -44,9 +47,6 @@ importers:
       sherif:
         specifier: ^1.0.0
         version: 1.0.0
-      simple-git-hooks:
-        specifier: ^2.9.0
-        version: 2.11.1
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -3324,6 +3324,11 @@ packages:
     resolution: {integrity: sha512-/1/GPCpDUCCYwlERiYjxoczfP0zfvZMU/OWgQPMya9AbAE24vseigFdhAMObpc8Q4lc/kjutPfUddDYyAmejnA==}
     engines: {node: '>=18.18.0'}
 
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
@@ -4682,10 +4687,6 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
-
-  simple-git-hooks@2.11.1:
-    resolution: {integrity: sha512-tgqwPUMDcNDhuf1Xf6KTUsyeqGdgKMhzaH4PAZZuzguOgTl5uuyeYe/8mWgAr6IBxB5V06uqEf6Dy37gIWDtDg==}
-    hasBin: true
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
@@ -8761,6 +8762,8 @@ snapshots:
 
   human-signals@8.0.0: {}
 
+  husky@9.1.7: {}
+
   iconv-lite@0.4.24:
     dependencies:
       safer-buffer: 2.1.2
@@ -10508,8 +10511,6 @@ snapshots:
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
-
-  simple-git-hooks@2.11.1: {}
 
   sisteransi@1.0.5: {}
 

--- a/scripts/checkBreakingChanges.ts
+++ b/scripts/checkBreakingChanges.ts
@@ -1,0 +1,165 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+const root = join(import.meta.dir, "..");
+
+// ANSI color codes
+const YELLOW = "\x1b[33m";
+const RED = "\x1b[31m";
+const RESET = "\x1b[0m";
+const BOLD = "\x1b[1m";
+
+// Built dynamically to avoid Biome's noControlCharactersInRegex rule.
+const ANSI_RE = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g");
+
+function stripAnsi(s: string): string {
+  return s.replace(ANSI_RE, "");
+}
+
+function git(...args: string[]): string {
+  const result = spawnSync("git", args, { cwd: root, encoding: "utf8" });
+  return result.stdout ?? "";
+}
+
+// Returns whether any changeset on disk declares a `major` bump.
+// Changesets persist until `pnpm changeset:version` consumes them.
+function hasMajorChangeset(): boolean {
+  const changesetDir = join(root, ".changeset");
+  if (!existsSync(changesetDir)) return false;
+
+  const files = readdirSync(changesetDir).filter(
+    (f) => f.endsWith(".md") && f !== "README.md",
+  );
+
+  return files.some((f) => {
+    const content = readFileSync(join(changesetDir, f), "utf8");
+    // Frontmatter format: ---\n"pkg": major|minor|patch\n---
+    const match = content.match(/^---\n([\s\S]*?)\n---/);
+    if (!match) return false;
+    return match[1].split("\n").some((line) => line.endsWith(": major"));
+  });
+}
+
+function hasAnyChangesetFile(): boolean {
+  const changesetDir = join(root, ".changeset");
+  if (!existsSync(changesetDir)) return false;
+  return readdirSync(changesetDir).some(
+    (f) => f.endsWith(".md") && f !== "README.md",
+  );
+}
+
+// Get staged diff for src/index.ts and find removed export names.
+function getRemovedExports(): string[] {
+  const diff = git("diff", "--cached", "--unified=0", "--", "src/index.ts");
+  if (!diff) return [];
+
+  const removed: string[] = [];
+
+  for (const line of diff.split("\n")) {
+    if (!line.startsWith("-")) continue;
+    // Match: -export { Foo, type Bar } or -  Foo,
+    const exportBlock = line.match(/^-export\s*\{([^}]+)\}/);
+    if (exportBlock) {
+      for (const name of exportBlock[1].split(",")) {
+        const clean = name.replace(/\btype\b/g, "").trim();
+        if (clean) removed.push(clean);
+      }
+      continue;
+    }
+    // Match single-name export line inside a multi-line block: -  SomeName,
+    const inlineMatch = line.match(/^-\s+([\w]+),?\s*$/);
+    if (inlineMatch) {
+      removed.push(inlineMatch[1]);
+    }
+  }
+
+  return removed;
+}
+
+// Check staged type files for removed fields in exported interfaces/types.
+function getRemovedTypeFields(): string[] {
+  const diff = git(
+    "diff",
+    "--cached",
+    "--unified=0",
+    "--",
+    "src/types",
+    "src/environments/types",
+    "src/client",
+  );
+  if (!diff) return [];
+
+  const removed: string[] = [];
+  let currentFile = "";
+
+  for (const line of diff.split("\n")) {
+    if (line.startsWith("+++ b/")) {
+      currentFile = line.slice(6);
+      continue;
+    }
+    if (!line.startsWith("-")) continue;
+    // Match removed field: -  fieldName: Type or -  fieldName?: Type
+    const fieldMatch = line.match(/^-\s{2,}(\w+)\??:/);
+    if (fieldMatch) {
+      removed.push(`${currentFile}: ${fieldMatch[1]}`);
+    }
+  }
+
+  return removed;
+}
+
+const removedExports = getRemovedExports();
+const removedFields = getRemovedTypeFields();
+const hasBreakingChanges =
+  removedExports.length > 0 || removedFields.length > 0;
+
+if (!hasBreakingChanges) process.exit(0);
+if (hasMajorChangeset()) process.exit(0);
+
+const anyChangeset = hasAnyChangesetFile();
+
+const border = "═".repeat(58);
+const headline = anyChangeset
+  ? `⚠  BREAKING CHANGE — changeset must be bumped to ${BOLD}major${RESET}${RED}${BOLD}`
+  : "⚠  BREAKING CHANGE DETECTED — no changeset found";
+const lines: string[] = [
+  `${BOLD}${YELLOW}╔${border}╗${RESET}`,
+  `${BOLD}${YELLOW}║${RESET}  ${RED}${BOLD}${headline}${RESET}  ${BOLD}${YELLOW}║${RESET}`,
+  `${BOLD}${YELLOW}╠${border}╣${RESET}`,
+];
+
+if (removedExports.length > 0) {
+  lines.push(
+    `${BOLD}${YELLOW}║${RESET}  Removed/renamed exports:${" ".repeat(31)}${BOLD}${YELLOW}║${RESET}`,
+  );
+  for (const name of removedExports) {
+    const padded = `    - ${name}`.padEnd(59);
+    lines.push(`${BOLD}${YELLOW}║${RESET}${padded}${BOLD}${YELLOW}║${RESET}`);
+  }
+}
+
+if (removedFields.length > 0) {
+  lines.push(
+    `${BOLD}${YELLOW}║${RESET}  Removed type fields:${" ".repeat(36)}${BOLD}${YELLOW}║${RESET}`,
+  );
+  for (const field of removedFields) {
+    const padded = `    - ${field}`.padEnd(59);
+    lines.push(`${BOLD}${YELLOW}║${RESET}${padded}${BOLD}${YELLOW}║${RESET}`);
+  }
+}
+
+lines.push(`${BOLD}${YELLOW}╠${border}╣${RESET}`);
+const action = anyChangeset
+  ? `Update your changeset bump type to ${BOLD}major${RESET}.`
+  : `Run: ${BOLD}pnpm changeset${RESET}  and select ${BOLD}major${RESET}.`;
+const padding = " ".repeat(Math.max(0, 57 - stripAnsi(action).length));
+lines.push(
+  `${BOLD}${YELLOW}║${RESET}  ${action}${padding}${BOLD}${YELLOW}║${RESET}`,
+);
+lines.push(`${BOLD}${YELLOW}╚${border}╝${RESET}`);
+
+process.stderr.write(`\n${lines.join("\n")}\n\n`);
+
+// Exit 0 — warn only, do not block the commit.
+process.exit(0);

--- a/scripts/checkBreakingChanges.ts
+++ b/scripts/checkBreakingChanges.ts
@@ -22,9 +22,9 @@ function git(...args: string[]): string {
   return result.stdout ?? "";
 }
 
-// Returns whether any changeset on disk declares a `major` bump.
+// Returns whether any changeset on disk declares a `minor` or `major` bump.
 // Changesets persist until `pnpm changeset:version` consumes them.
-function hasMajorChangeset(): boolean {
+function hasSufficientChangeset(): boolean {
   const changesetDir = join(root, ".changeset");
   if (!existsSync(changesetDir)) return false;
 
@@ -37,7 +37,9 @@ function hasMajorChangeset(): boolean {
     // Frontmatter format: ---\n"pkg": major|minor|patch\n---
     const match = content.match(/^---\n([\s\S]*?)\n---/);
     if (!match) return false;
-    return match[1].split("\n").some((line) => line.endsWith(": major"));
+    return match[1]
+      .split("\n")
+      .some((line) => line.endsWith(": major") || line.endsWith(": minor"));
   });
 }
 
@@ -115,13 +117,13 @@ const hasBreakingChanges =
   removedExports.length > 0 || removedFields.length > 0;
 
 if (!hasBreakingChanges) process.exit(0);
-if (hasMajorChangeset()) process.exit(0);
+if (hasSufficientChangeset()) process.exit(0);
 
 const anyChangeset = hasAnyChangesetFile();
 
 const border = "═".repeat(58);
 const headline = anyChangeset
-  ? `⚠  BREAKING CHANGE — changeset must be bumped to ${BOLD}major${RESET}${RED}${BOLD}`
+  ? `⚠  BREAKING CHANGE — changeset must be bumped to ${BOLD}minor${RESET}${RED}${BOLD} or ${BOLD}major${RESET}${RED}${BOLD}`
   : "⚠  BREAKING CHANGE DETECTED — no changeset found";
 const lines: string[] = [
   `${BOLD}${YELLOW}╔${border}╗${RESET}`,
@@ -151,8 +153,8 @@ if (removedFields.length > 0) {
 
 lines.push(`${BOLD}${YELLOW}╠${border}╣${RESET}`);
 const action = anyChangeset
-  ? `Update your changeset bump type to ${BOLD}major${RESET}.`
-  : `Run: ${BOLD}pnpm changeset${RESET}  and select ${BOLD}major${RESET}.`;
+  ? `Update your changeset bump type to ${BOLD}minor${RESET} or ${BOLD}major${RESET}.`
+  : `Run: ${BOLD}pnpm changeset${RESET}  and select ${BOLD}minor${RESET} or ${BOLD}major${RESET}.`;
 const padding = " ".repeat(Math.max(0, 57 - stripAnsi(action).length));
 lines.push(
   `${BOLD}${YELLOW}║${RESET}  ${action}${padding}${BOLD}${YELLOW}║${RESET}`,


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                     
  - Replaces `simple-git-hooks` with Husky for consistency with our other projects
  - Adds a `pre-commit` hook (`scripts/checkBreakingChanges.ts`) that detects breaking
    SDK changes in staged files — removed exports from `src/index.ts` and removed fields
    from exported types
  - Warns if no `minor` or `major` changeset is present (accepts `minor` since the SDK
    is pre-1.0); never blocks the commit

  ## Test plan
  - [ ] Commit a non-breaking change — hook is silent
  - [ ] Remove an export, commit without a changeset — warning appears
  - [ ] Same with a `patch` changeset — warning asks to bump to `minor` or `major`
  - [ ] Same with a `minor` or `major` changeset — hook is silent



<img width="1153" height="251" alt="Screenshot 2026-04-13 at 11 45 32" src="https://github.com/user-attachments/assets/ac555f76-103f-4a38-8a18-6ec6d9b724e3" />


