### PR TITLE
Stop calling the deprecated Morpho URD endpoint and route post-Artemis Moonbeam proposals to the multichain governor

### DIFF
--- a/.changeset/slimy-badgers-open.md
+++ b/.changeset/slimy-badgers-open.md
@@ -1,0 +1,5 @@
+---
+"@moonwell-fi/moonwell-sdk": patch
+---
+
+Stop calling the deprecated Morpho URD endpoint and route post-Artemis Moonbeam proposals to the multichain governor

--- a/src/actions/governance/proposals/common.test.ts
+++ b/src/actions/governance/proposals/common.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "vitest";
+import {
+  WORMHOLE_CONTRACT,
+  isMultichainAware,
+  isMultichainProposal,
+} from "./common.js";
+
+const LOCAL_TARGET = "0xed301cd3eb27217bdb05c4e9b820a8a3c8b665f9";
+
+describe("isMultichainProposal", () => {
+  test("matches when targets include the Wormhole bridge", () => {
+    expect(isMultichainProposal([WORMHOLE_CONTRACT])).toBe(true);
+  });
+
+  test("matches when Wormhole address is uppercase", () => {
+    expect(isMultichainProposal([WORMHOLE_CONTRACT.toUpperCase()])).toBe(true);
+  });
+
+  test("returns false when targets don't include Wormhole", () => {
+    expect(isMultichainProposal([LOCAL_TARGET])).toBe(false);
+  });
+
+  test("returns false for undefined or empty targets", () => {
+    expect(isMultichainProposal(undefined)).toBe(false);
+    expect(isMultichainProposal([])).toBe(false);
+  });
+});
+
+describe("isMultichainAware", () => {
+  test("returns true when targets include Wormhole even if proposalId is below cutoff", () => {
+    expect(
+      isMultichainAware({ targets: [WORMHOLE_CONTRACT], proposalId: 10 }, 100),
+    ).toBe(true);
+  });
+
+  test("returns true when proposalId is past the legacy Artemis cutoff", () => {
+    expect(
+      isMultichainAware({ targets: [LOCAL_TARGET], proposalId: 93 }, 86),
+    ).toBe(true);
+  });
+
+  test("returns false when proposalId is at or below the cutoff and no Wormhole target", () => {
+    expect(
+      isMultichainAware({ targets: [LOCAL_TARGET], proposalId: 86 }, 86),
+    ).toBe(false);
+    expect(
+      isMultichainAware({ targets: [LOCAL_TARGET], proposalId: 50 }, 86),
+    ).toBe(false);
+  });
+
+  test("falls back to targets-only when legacyArtemisMaxId is 0 (proposalCount RPC failed)", () => {
+    expect(
+      isMultichainAware({ targets: [WORMHOLE_CONTRACT], proposalId: 999 }, 0),
+    ).toBe(true);
+    expect(
+      isMultichainAware({ targets: [LOCAL_TARGET], proposalId: 999 }, 0),
+    ).toBe(false);
+  });
+
+  test("returns false for an unknown proposal (no targets, no past-cutoff id)", () => {
+    expect(isMultichainAware({ proposalId: 1 }, 86)).toBe(false);
+  });
+});

--- a/src/actions/governance/proposals/common.ts
+++ b/src/actions/governance/proposals/common.ts
@@ -201,9 +201,28 @@ export const getProposalsOnChainData = async (
     }
   }
 
+  // Read once: highest proposalId held by the legacy Artemis governor.
+  // Anything with a higher proposalId belongs to the multichain governor,
+  // even if its targets don't include the Wormhole bridge (e.g., proposals
+  // that only touch contracts on the home chain).
+  let legacyArtemisMaxId = 0;
+  if (governanceEnvironment.contracts.governor) {
+    try {
+      const count =
+        await governanceEnvironment.contracts.governor.read.proposalCount();
+      legacyArtemisMaxId = Number(count);
+    } catch (error) {
+      console.warn("Failed to fetch legacy governor proposalCount:", error);
+    }
+  }
+
+  const isMultichainAware = (p: ApiProposal): boolean =>
+    isMultichainProposal(p.targets) ||
+    (legacyArtemisMaxId > 0 && p.proposalId > legacyArtemisMaxId);
+
   const onChainDataList = await Promise.all(
     apiProposals.map(async (p) => {
-      const isMultichain = isMultichainProposal(p.targets);
+      const isMultichain = isMultichainAware(p);
 
       const governorContract = isMultichain
         ? governanceEnvironment.contracts.multichainGovernor
@@ -242,7 +261,7 @@ export const getProposalsOnChainData = async (
 
   const votesCollectedList = await Promise.all(
     apiProposals.map(async (apiProposal) => {
-      const isMultichain = isMultichainProposal(apiProposal.targets);
+      const isMultichain = isMultichainAware(apiProposal);
 
       if (
         !isMultichain ||

--- a/src/actions/governance/proposals/common.ts
+++ b/src/actions/governance/proposals/common.ts
@@ -99,6 +99,24 @@ export const isMultichainProposal = (targets?: string[]): boolean => {
   );
 };
 
+/**
+ * Routes a proposal to the multichain governor when:
+ *   - its targets include the Wormhole bridge (legacy detection), OR
+ *   - its proposalId is past the legacy Artemis governor's `proposalCount`,
+ *     which means it could only have been created on the multichain governor
+ *     (proposals migrated to the multichain governor after the cutoff but
+ *     can have local-only targets, e.g. Moonbeam-internal contract calls).
+ *
+ * `legacyArtemisMaxId === 0` indicates the count read failed; in that case we
+ * fall back to the targets-only heuristic.
+ */
+export const isMultichainAware = (
+  proposal: { targets?: string[]; proposalId: number },
+  legacyArtemisMaxId: number,
+): boolean =>
+  isMultichainProposal(proposal.targets) ||
+  (legacyArtemisMaxId > 0 && proposal.proposalId > legacyArtemisMaxId);
+
 export type ApiProposalFormatted = {
   forVotes: Amount;
   againstVotes: Amount;
@@ -237,13 +255,9 @@ export const getProposalsOnChainData = async (
 
   const legacyArtemisMaxId = await getLegacyArtemisMaxId(governanceEnvironment);
 
-  const isMultichainAware = (p: ApiProposal): boolean =>
-    isMultichainProposal(p.targets) ||
-    (legacyArtemisMaxId > 0 && p.proposalId > legacyArtemisMaxId);
-
   const onChainDataList = await Promise.all(
     apiProposals.map(async (p) => {
-      const isMultichain = isMultichainAware(p);
+      const isMultichain = isMultichainAware(p, legacyArtemisMaxId);
 
       const governorContract = isMultichain
         ? governanceEnvironment.contracts.multichainGovernor
@@ -282,7 +296,7 @@ export const getProposalsOnChainData = async (
 
   const votesCollectedList = await Promise.all(
     apiProposals.map(async (apiProposal) => {
-      const isMultichain = isMultichainAware(apiProposal);
+      const isMultichain = isMultichainAware(apiProposal, legacyArtemisMaxId);
 
       if (
         !isMultichain ||

--- a/src/actions/governance/proposals/common.ts
+++ b/src/actions/governance/proposals/common.ts
@@ -181,6 +181,40 @@ export type ProposalOnChainData = {
   quorum: bigint;
 };
 
+// Cached per chain: highest proposalId held by the legacy Artemis governor.
+// Anything with a higher proposalId belongs to the multichain governor, even
+// if its targets don't include the Wormhole bridge. The legacy governor only
+// receives new proposals during chain migrations, so a 5-minute TTL is plenty.
+const LEGACY_ARTEMIS_MAX_ID_TTL_MS = 5 * 60 * 1000;
+const legacyArtemisMaxIdCache = new Map<
+  number,
+  { value: number; fetchedAt: number }
+>();
+
+const getLegacyArtemisMaxId = async (
+  governanceEnvironment: Environment,
+): Promise<number> => {
+  const governor = governanceEnvironment.contracts.governor;
+  if (!governor) return 0;
+
+  const cached = legacyArtemisMaxIdCache.get(governanceEnvironment.chainId);
+  if (cached && Date.now() - cached.fetchedAt < LEGACY_ARTEMIS_MAX_ID_TTL_MS) {
+    return cached.value;
+  }
+
+  try {
+    const value = Number(await governor.read.proposalCount());
+    legacyArtemisMaxIdCache.set(governanceEnvironment.chainId, {
+      value,
+      fetchedAt: Date.now(),
+    });
+    return value;
+  } catch (error) {
+    console.warn("Failed to fetch legacy governor proposalCount:", error);
+    return cached?.value ?? 0;
+  }
+};
+
 /**
  * Fetches on-chain data for multiple proposals
  */
@@ -201,20 +235,7 @@ export const getProposalsOnChainData = async (
     }
   }
 
-  // Read once: highest proposalId held by the legacy Artemis governor.
-  // Anything with a higher proposalId belongs to the multichain governor,
-  // even if its targets don't include the Wormhole bridge (e.g., proposals
-  // that only touch contracts on the home chain).
-  let legacyArtemisMaxId = 0;
-  if (governanceEnvironment.contracts.governor) {
-    try {
-      const count =
-        await governanceEnvironment.contracts.governor.read.proposalCount();
-      legacyArtemisMaxId = Number(count);
-    } catch (error) {
-      console.warn("Failed to fetch legacy governor proposalCount:", error);
-    }
-  }
+  const legacyArtemisMaxId = await getLegacyArtemisMaxId(governanceEnvironment);
 
   const isMultichainAware = (p: ApiProposal): boolean =>
     isMultichainProposal(p.targets) ||

--- a/src/actions/morpho/user-rewards/common.test.ts
+++ b/src/actions/morpho/user-rewards/common.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import type { Environment } from "../../../environments/index.js";
+import type { MorphoUserReward } from "../../../types/morphoUserReward.js";
+import { getUserMorphoRewardsData } from "./common.js";
+
+type MerklReward = Extract<MorphoUserReward, { type: "merkl-reward" }>;
+
+const ACCOUNT = "0x1234567890abcdef1234567890abcdef12345678" as const;
+
+// A real Moonwell vault campaignId from base/morpho-vaults.ts. The vault
+// campaign filtering in `getUserMorphoRewardsData` should keep this one.
+const MOONWELL_VAULT_CAMPAIGN =
+  "0x1df9a935f6b928b4809c4fda483f16839140864b2b412cc5fea85fd5d9d00e57";
+
+// Not in any publicEnvironments vault config — should be filtered out on
+// full-deployment chains.
+const NON_MOONWELL_CAMPAIGN =
+  "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+const WELL_TOKEN = {
+  address: "0xA88594D404727625A9437C3f886C7643872296AE",
+  chainId: 8453,
+  symbol: "WELL",
+  decimals: 18,
+  price: 0.004,
+};
+
+const baseEnvironment = {
+  chainId: 8453,
+  custom: { morpho: { minimalDeployment: false } },
+} as unknown as Environment;
+
+const optimismEnvironment = {
+  chainId: 10,
+  custom: {},
+} as unknown as Environment;
+
+function makeMerklResponse(
+  rewardOverrides: { amount: string; claimed: string; pending: string },
+  breakdowns: {
+    campaignId: string;
+    amount: string;
+    claimed: string;
+    pending: string;
+  }[],
+) {
+  return [
+    {
+      chain: { id: 8453, name: "Base", icon: "" },
+      rewards: [
+        {
+          root: "0x",
+          recipient: ACCOUNT,
+          amount: rewardOverrides.amount,
+          claimed: rewardOverrides.claimed,
+          pending: rewardOverrides.pending,
+          proofs: [],
+          token: WELL_TOKEN,
+          breakdowns: breakdowns.map((b) => ({ reason: "campaign", ...b })),
+        },
+      ],
+    },
+  ];
+}
+
+function mockFetchOnce(data: unknown) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(data),
+      }),
+    ),
+  );
+}
+
+describe("getUserMorphoRewardsData", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("on full deployments, restricts to Moonwell vault campaigns", async () => {
+    mockFetchOnce(
+      makeMerklResponse(
+        // Top-level totals across all campaigns.
+        { amount: "1000", claimed: "200", pending: "50" },
+        [
+          // Counts.
+          {
+            campaignId: MOONWELL_VAULT_CAMPAIGN,
+            amount: "600",
+            claimed: "100",
+            pending: "30",
+          },
+          // Excluded.
+          {
+            campaignId: NON_MOONWELL_CAMPAIGN,
+            amount: "400",
+            claimed: "100",
+            pending: "20",
+          },
+        ],
+      ),
+    );
+
+    const result = await getUserMorphoRewardsData({
+      environment: baseEnvironment,
+      account: ACCOUNT,
+    });
+
+    expect(result).toHaveLength(1);
+    const reward = result[0] as MerklReward;
+    expect(reward.type).toBe("merkl-reward");
+    // Filtered amounts: 600 - 100 = 500 claimable now, 30 future.
+    expect(reward.claimableNow.exponential).toBe(500n);
+    expect(reward.claimableFuture.exponential).toBe(30n);
+    expect(reward.rewardToken.symbol).toBe("WELL");
+  });
+
+  test("on minimal deployments, uses unfiltered top-level reward totals", async () => {
+    mockFetchOnce(
+      makeMerklResponse({ amount: "1000", claimed: "200", pending: "50" }, [
+        {
+          campaignId: NON_MOONWELL_CAMPAIGN,
+          amount: "400",
+          claimed: "100",
+          pending: "20",
+        },
+      ]),
+    );
+
+    const result = await getUserMorphoRewardsData({
+      environment: optimismEnvironment,
+      account: ACCOUNT,
+    });
+
+    expect(result).toHaveLength(1);
+    const reward = result[0] as MerklReward;
+    // Top-level totals: 1000 - 200 = 800 claimable now, 50 future.
+    expect(reward.claimableNow.exponential).toBe(800n);
+    expect(reward.claimableFuture.exponential).toBe(50n);
+  });
+
+  test("returns empty array when Merkl returns no rewards", async () => {
+    mockFetchOnce([]);
+
+    const result = await getUserMorphoRewardsData({
+      environment: baseEnvironment,
+      account: ACCOUNT,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  test("returns empty array when Merkl request fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve({
+          ok: false,
+          status: 500,
+          statusText: "Internal Server Error",
+        }),
+      ),
+    );
+
+    const result = await getUserMorphoRewardsData({
+      environment: baseEnvironment,
+      account: ACCOUNT,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  test("on full deployments, returns zero claimable when no breakdowns match Moonwell campaigns", async () => {
+    mockFetchOnce(
+      makeMerklResponse({ amount: "1000", claimed: "200", pending: "50" }, [
+        {
+          campaignId: NON_MOONWELL_CAMPAIGN,
+          amount: "400",
+          claimed: "100",
+          pending: "20",
+        },
+      ]),
+    );
+
+    const result = await getUserMorphoRewardsData({
+      environment: baseEnvironment,
+      account: ACCOUNT,
+    });
+
+    expect(result).toHaveLength(1);
+    const reward = result[0] as MerklReward;
+    expect(reward.claimableNow.exponential).toBe(0n);
+    expect(reward.claimableFuture.exponential).toBe(0n);
+  });
+});

--- a/src/actions/morpho/user-rewards/common.ts
+++ b/src/actions/morpho/user-rewards/common.ts
@@ -23,13 +23,14 @@ export async function getUserMorphoRewardsData(params: {
   const isFullDeployment =
     params.environment.custom.morpho?.minimalDeployment === false;
 
-  const emptyMorphoRewards: MorphoRewardsResponse[] = [];
-  const [merklRewards, morphoRewards] = await Promise.all([
-    getMerklRewardsData(params.environment, params.account),
-    isFullDeployment
-      ? getMorphoRewardsData(params.environment, params.account)
-      : Promise.resolve(emptyMorphoRewards),
-  ]);
+  // The Morpho URD distributions endpoint (rewards.morpho.org) was
+  // deprecated and now 301-redirects to a SPA, so JSON parsing fails.
+  // Skip it; surface only Merkl rewards.
+  const merklRewards = await getMerklRewardsData(
+    params.environment,
+    params.account,
+  );
+  const morphoRewards: MorphoRewardsResponse[] = [];
 
   if (isFullDeployment) {
     // Process Morpho rewards (GraphQL query depends on morphoRewards result)
@@ -495,22 +496,6 @@ type MorphoAssetResponse = {
   name: string;
   decimals: number;
 };
-
-async function getMorphoRewardsData(
-  environment: Environment,
-  account: Address,
-): Promise<MorphoRewardsResponse[]> {
-  const baseUrl =
-    environment.custom.morpho?.rewardsApiUrl || "https://rewards.morpho.org";
-  const rewardsRequest = await fetch(
-    `${baseUrl}/v1/users/${account}/rewards?chain_id=${environment.chainId}&trusted=true&exclude_merkl_programs=true`,
-    {
-      headers: MOONWELL_FETCH_JSON_HEADERS,
-    },
-  );
-  const rewards = await rewardsRequest.json();
-  return (rewards.data || []) as MorphoRewardsResponse[];
-}
 
 async function getMorphoAssetsData(
   environment: Environment,

--- a/src/actions/morpho/user-rewards/common.ts
+++ b/src/actions/morpho/user-rewards/common.ts
@@ -1,5 +1,3 @@
-import lodash from "lodash";
-const { uniq } = lodash;
 import { type Address, getContract, parseAbi, zeroAddress } from "viem";
 import { Amount } from "../../../common/amount.js";
 import { MOONWELL_FETCH_JSON_HEADERS } from "../../../common/fetch-headers.js";
@@ -14,258 +12,53 @@ import {
 } from "../../../environments/utils/index.js";
 import type { MorphoUserReward } from "../../../types/morphoUserReward.js";
 import type { MorphoUserStakingReward } from "../../../types/morphoUserStakingReward.js";
-import { getGraphQL } from "../utils/graphql.js";
 
 export async function getUserMorphoRewardsData(params: {
   environment: Environment;
   account: `0x${string}`;
 }): Promise<MorphoUserReward[]> {
-  const isFullDeployment =
-    params.environment.custom.morpho?.minimalDeployment === false;
-
   // The Morpho URD distributions endpoint (rewards.morpho.org) was
   // deprecated and now 301-redirects to a SPA, so JSON parsing fails.
-  // Skip it; surface only Merkl rewards.
+  // Surface only Merkl rewards.
   const merklRewards = await getMerklRewardsData(
     params.environment,
     params.account,
   );
-  const morphoRewards: MorphoRewardsResponse[] = [];
 
-  if (isFullDeployment) {
-    // Process Morpho rewards (GraphQL query depends on morphoRewards result)
-    const morphoAssets = await getMorphoAssetsData(
-      params.environment,
-      morphoRewards.map((r) => r.asset.address),
+  const isFullDeployment =
+    params.environment.custom.morpho?.minimalDeployment === false;
+
+  // For full deployments (Base), restrict to Moonwell vault campaigns so the
+  // result excludes staking and other Moonwell campaigns; those are returned
+  // by their own actions (e.g. getUserStakingInfo). On other chains, surface
+  // every Merkl reward we get back.
+  const vaultCampaignIds = isFullDeployment
+    ? new Set<string>(
+        (Object.values(publicEnvironments) as Environment[]).flatMap(
+          (environment) =>
+            Object.values(environment.config.vaults ?? {})
+              .map((vault) => vault.campaignId)
+              .filter((id): id is string => id !== undefined),
+        ),
+      )
+    : null;
+
+  const sumBreakdowns = (
+    breakdowns: {
+      campaignId: string;
+      amount: string;
+      claimed: string;
+      pending: string;
+    }[],
+    field: "amount" | "claimed" | "pending",
+  ): bigint =>
+    breakdowns.reduce(
+      (acc, curr) =>
+        vaultCampaignIds === null || vaultCampaignIds.has(curr.campaignId)
+          ? acc + BigInt(curr[field])
+          : acc,
+      0n,
     );
-
-    const morphoResult: (MorphoUserReward | undefined)[] = morphoRewards.map(
-      (r) => {
-        const asset = morphoAssets.find(
-          (a) => a.address.toLowerCase() === r.asset.address.toLowerCase(),
-        );
-
-        if (!asset) {
-          return undefined;
-        }
-
-        const rewardToken: TokenConfig = {
-          address: asset.address,
-          decimals: asset.decimals,
-          symbol: asset.symbol,
-          name: asset.name,
-        };
-
-        switch (r.type) {
-          case "uniform-reward": {
-            const claimableNow = new Amount(
-              BigInt(r.amount?.claimable_now || 0),
-              rewardToken.decimals,
-            );
-            const claimableNowUsd = claimableNow.value * (asset.priceUsd || 0);
-            const claimableFuture = new Amount(
-              BigInt(r.amount?.claimable_next || 0),
-              rewardToken.decimals,
-            );
-            const claimableFutureUsd =
-              claimableFuture.value * (asset.priceUsd || 0);
-
-            const uniformReward: MorphoUserReward = {
-              type: "uniform-reward",
-              chainId: r.asset.chain_id,
-              account: r.user,
-              rewardToken,
-              claimableNow,
-              claimableNowUsd,
-              claimableFuture,
-              claimableFutureUsd,
-            };
-            return uniformReward;
-          }
-
-          case "market-reward": {
-            const claimableNow = new Amount(
-              BigInt(r.for_supply?.claimable_now || 0),
-              rewardToken.decimals,
-            );
-            const claimableNowUsd = claimableNow.value * (asset.priceUsd || 0);
-
-            const claimableFuture = new Amount(
-              BigInt(r.for_supply?.claimable_next || 0),
-              rewardToken.decimals,
-            );
-            const claimableFutureUsd =
-              claimableFuture.value * (asset.priceUsd || 0);
-
-            const collateralClaimableNow = new Amount(
-              BigInt(r.for_collateral?.claimable_now || 0),
-              rewardToken.decimals,
-            );
-            const collateralClaimableNowUsd =
-              collateralClaimableNow.value * (asset.priceUsd || 0);
-            const collateralClaimableFuture = new Amount(
-              BigInt(r.for_collateral?.claimable_next || 0),
-              rewardToken.decimals,
-            );
-            const collateralClaimableFutureUsd =
-              collateralClaimableFuture.value * (asset.priceUsd || 0);
-
-            const borrowClaimableNow = new Amount(
-              BigInt(r.for_borrow?.claimable_now || 0),
-              rewardToken.decimals,
-            );
-            const borrowClaimableNowUsd =
-              borrowClaimableNow.value * (asset.priceUsd || 0);
-            const borrowClaimableFuture = new Amount(
-              BigInt(r.for_borrow?.claimable_next || 0),
-              rewardToken.decimals,
-            );
-            const borrowClaimableFutureUsd =
-              borrowClaimableFuture.value * (asset.priceUsd || 0);
-
-            //Rewards reallocated to vaults are reported as vault rewards
-            if (r.reallocated_from) {
-              const vaultReward: MorphoUserReward = {
-                type: "vault-reward",
-                chainId: r.program.chain_id,
-                account: r.user,
-                vaultId: r.reallocated_from,
-                rewardToken,
-                claimableNow,
-                claimableNowUsd,
-                claimableFuture,
-                claimableFutureUsd,
-              };
-              return vaultReward;
-            } else {
-              const marketReward: MorphoUserReward = {
-                type: "market-reward",
-                chainId: r.program.chain_id,
-                account: r.user,
-                marketId: r.program.market_id || "",
-                rewardToken,
-                collateralRewards: {
-                  claimableNow: collateralClaimableNow,
-                  claimableNowUsd: collateralClaimableNowUsd,
-                  claimableFuture: collateralClaimableFuture,
-                  claimableFutureUsd: collateralClaimableFutureUsd,
-                },
-                borrowRewards: {
-                  claimableNow: borrowClaimableNow,
-                  claimableNowUsd: borrowClaimableNowUsd,
-                  claimableFuture: borrowClaimableFuture,
-                  claimableFutureUsd: borrowClaimableFutureUsd,
-                },
-              };
-              return marketReward;
-            }
-          }
-          case "vault-reward": {
-            const claimableNow = new Amount(
-              BigInt(r.for_supply?.claimable_now || 0),
-              rewardToken.decimals,
-            );
-            const claimableNowUsd = claimableNow.value * (asset.priceUsd || 0);
-            const claimableFuture = new Amount(
-              BigInt(r.for_supply?.claimable_next || 0),
-              rewardToken.decimals,
-            );
-            const claimableFutureUsd =
-              claimableFuture.value * (asset.priceUsd || 0);
-
-            const vaultReward: MorphoUserReward = {
-              type: "vault-reward",
-              chainId: r.program.chain_id,
-              account: r.user,
-              vaultId: r.program.vault,
-              rewardToken,
-              claimableNow,
-              claimableNowUsd,
-              claimableFuture,
-              claimableFutureUsd,
-            };
-
-            return vaultReward;
-          }
-        }
-      },
-    );
-
-    // Process Merkl rewards
-    const vaultCampaignIds = new Set<string>(
-      (Object.values(publicEnvironments) as Environment[]).flatMap(
-        (environment) =>
-          Object.values(environment.config.vaults ?? {})
-            .map((vault) => vault.campaignId)
-            .filter((id): id is string => id !== undefined),
-      ),
-    );
-
-    const getVaultRewardAmount = (
-      breakdowns: any[],
-      field: "amount" | "claimed" | "pending",
-    ) => {
-      return breakdowns.reduce(
-        (acc, curr) =>
-          vaultCampaignIds.has(curr.campaignId)
-            ? acc + BigInt(curr[field])
-            : acc,
-        0n,
-      );
-    };
-
-    const merklResult: MorphoUserReward[] = [];
-
-    for (const chainData of merklRewards) {
-      for (const reward of chainData.rewards) {
-        // Try to find token info in morphoAssets first
-        const morphoAsset = morphoAssets.find(
-          (a) => a.address.toLowerCase() === reward.token.address.toLowerCase(),
-        );
-
-        const rewardToken: TokenConfig = {
-          address: reward.token.address as Address,
-          decimals: morphoAsset?.decimals ?? reward.token.decimals,
-          symbol: morphoAsset?.symbol ?? reward.token.symbol,
-          name: morphoAsset?.name ?? reward.token.symbol,
-        };
-
-        const amount = getVaultRewardAmount(reward.breakdowns, "amount");
-        const claimed = getVaultRewardAmount(reward.breakdowns, "claimed");
-        const pending = getVaultRewardAmount(reward.breakdowns, "pending");
-
-        const claimableNow = new Amount(amount - claimed, rewardToken.decimals);
-        const claimableNowUsd =
-          claimableNow.value *
-          (morphoAsset?.priceUsd ?? reward.token.price ?? 0);
-        const claimableFuture = new Amount(pending, rewardToken.decimals);
-        const claimableFutureUsd =
-          claimableFuture.value *
-          (morphoAsset?.priceUsd ?? reward.token.price ?? 0);
-
-        const merklReward: MorphoUserReward = {
-          type: "merkl-reward",
-          chainId: chainData.chain.id,
-          account: params.account,
-          rewardToken,
-          claimableNow,
-          claimableNowUsd,
-          claimableFuture,
-          claimableFutureUsd,
-        };
-
-        merklResult.push(merklReward);
-      }
-    }
-
-    // Combine both results
-    const allResults = [
-      ...(morphoResult.filter((r) => r !== undefined) as MorphoUserReward[]),
-      ...merklResult,
-    ];
-
-    return allResults;
-  }
 
   const merklResult: MorphoUserReward[] = [];
 
@@ -278,19 +71,23 @@ export async function getUserMorphoRewardsData(params: {
         name: reward.token.symbol,
       };
 
-      const claimableNow = new Amount(
-        BigInt(reward.amount) - BigInt(reward.claimed),
-        rewardToken.decimals,
-      );
+      const amount = vaultCampaignIds
+        ? sumBreakdowns(reward.breakdowns, "amount")
+        : BigInt(reward.amount);
+      const claimed = vaultCampaignIds
+        ? sumBreakdowns(reward.breakdowns, "claimed")
+        : BigInt(reward.claimed);
+      const pending = vaultCampaignIds
+        ? sumBreakdowns(reward.breakdowns, "pending")
+        : BigInt(reward.pending);
+
+      const claimableNow = new Amount(amount - claimed, rewardToken.decimals);
       const claimableNowUsd = claimableNow.value * (reward.token.price ?? 0);
-      const claimableFuture = new Amount(
-        BigInt(reward.pending),
-        rewardToken.decimals,
-      );
+      const claimableFuture = new Amount(pending, rewardToken.decimals);
       const claimableFutureUsd =
         claimableFuture.value * (reward.token.price ?? 0);
 
-      const merklReward: MorphoUserReward = {
+      merklResult.push({
         type: "merkl-reward",
         chainId: chainData.chain.id,
         account: params.account,
@@ -299,9 +96,7 @@ export async function getUserMorphoRewardsData(params: {
         claimableNowUsd,
         claimableFuture,
         claimableFutureUsd,
-      };
-
-      merklResult.push(merklReward);
+      });
     }
   }
 
@@ -456,78 +251,6 @@ const getRewardsEarnedData = async (
 
   return rewards.filter(Boolean);
 };
-
-type MorphoRewardsResponse = {
-  user: Address;
-  for_borrow: {
-    claimable_next: string;
-    claimable_now: string;
-    claimed: string;
-    total: string;
-  };
-  for_collateral: {
-    claimable_next: string;
-    claimable_now: string;
-    claimed: string;
-    total: string;
-  };
-  for_supply: {
-    claimable_next: string;
-    claimable_now: string;
-    claimed: string;
-    total: string;
-  };
-  program: {
-    asset: { address: Address };
-    market_id?: string;
-    chain_id: number;
-    vault: Address;
-  };
-  asset: { address: Address; chain_id: number };
-  amount?: { claimable_next: string; claimable_now: string };
-  type: "vault-reward" | "market-reward" | "uniform-reward";
-  reallocated_from: Address;
-};
-
-type MorphoAssetResponse = {
-  address: Address;
-  symbol: string;
-  priceUsd: number | undefined;
-  name: string;
-  decimals: number;
-};
-
-async function getMorphoAssetsData(
-  environment: Environment,
-  addresses: Address[],
-): Promise<MorphoAssetResponse[]> {
-  const rewardsRequest = await getGraphQL<{
-    assets: {
-      items: MorphoAssetResponse[];
-    };
-  }>(
-    environment,
-    `
-    query {
-      assets(where: { address_in:[${uniq(addresses)
-        .map((a: string) => `"${a.toLowerCase()}"`)
-        .join(",")}]}) {
-        items {
-          address     
-          symbol
-          priceUsd
-          name
-          decimals
-        }
-      }
-    }
-  `,
-  );
-  if (rewardsRequest) {
-    return rewardsRequest.assets.items;
-  }
-  return [];
-}
 
 type MerklRewardsResponse = {
   chain: {


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                     
  - Stop calling the deprecated `rewards.morpho.org/v1/users/.../distributions` endpoint inside `getUserMorphoRewardsData` — it now 301-redirects to a SPA and was making `getMorphoUserRewards` reject on Base.
  - Route Moonbeam proposals past the legacy Artemis cutoff to the multichain governor even when their targets don't include Wormhole, killing the `GovernorArtemis::state: invalid proposal id` console spam and surfacing correct              
  `state`/`eta`.                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                 
  ## Test plan                                                                                                                                                                                                                                   
  - [x] `pnpm tsc --noEmit` and `pnpm lint` pass            
  - [x] Frontend `/portfolio` on Base: no requests to `rewards.morpho.org`; vault rewards still surface (via Merkl)                                                                                                                              
  - [x] Frontend `/governance` on Moonbeam: proposals 87+ render with correct on-chain state; no `invalid proposal id` warnings  