### PR TITLE
enable transfer well to eth mainnet

### DIFF
--- a/.changeset/calm-clouds-fall.md
+++ b/.changeset/calm-clouds-fall.md
@@ -1,0 +1,5 @@
+---
+"@moonwell-fi/moonwell-sdk": minor
+---
+
+Add Ethereum mainnet environment with xWELL token + Wormhole adapter for WELL→Ethereum transfers, voting-power reads, and circulating-supply snapshots via Lunar Indexer

--- a/src/actions/governance/getDelegates.ts
+++ b/src/actions/governance/getDelegates.ts
@@ -28,6 +28,8 @@ export async function getDelegates(
   const apiVoters = await fetchAllVoters(governanceEnvironment);
   const forumProfiles = await getForumProfiles();
 
+  // TODO: include mainnet.id once Ethereum's views contract ships, to match
+  // WELL.chainIds in environments/definitions/governance.ts.
   const targetChainIds = [moonbeam.id, base.id, optimism.id] as const;
   const envs = Object.values(client.environments as Environment[]).filter(
     (env) =>

--- a/src/actions/governance/getUserVotingPowers.test.ts
+++ b/src/actions/governance/getUserVotingPowers.test.ts
@@ -185,7 +185,6 @@ describe("getUserVotingPowers — snapshotTimestamp", () => {
   });
 
   test("environments without a views contract are excluded from results", async () => {
-    const noViewsRead = vi.fn();
     const validRead = vi.fn(async () => ZERO_USER_VOTES);
 
     const client = {
@@ -211,8 +210,60 @@ describe("getUserVotingPowers — snapshotTimestamp", () => {
       blockNumber: 42n,
     });
 
-    expect(noViewsRead).not.toHaveBeenCalled();
     expect(validRead).toHaveBeenCalledTimes(1);
     expect(result.map((r) => r.chainId)).toEqual([8453]);
+  });
+
+  test("snapshotTimestamp preserves index correlation across a mixed [noViews, valid, noViews, valid] env list", async () => {
+    const validReadB = vi.fn(async () => ZERO_USER_VOTES);
+    const validReadD = vi.fn(async () => ZERO_USER_VOTES);
+
+    const client = {
+      environments: {
+        chainA: {
+          chainId: 1,
+          custom: { governance: { token: "WELL" } },
+          contracts: {},
+          publicClient: {},
+        },
+        chainB: {
+          chainId: 8453,
+          custom: { governance: { token: "WELL" } },
+          contracts: {
+            views: { read: { getUserVotingPower: validReadB } },
+          },
+          publicClient: {},
+        },
+        chainC: {
+          chainId: 137,
+          custom: { governance: { token: "WELL" } },
+          contracts: {},
+          publicClient: {},
+        },
+        chainD: {
+          chainId: 10,
+          custom: { governance: { token: "WELL" } },
+          contracts: {
+            views: { read: { getUserVotingPower: validReadD } },
+          },
+          publicClient: {},
+        },
+      },
+    } as unknown as MoonwellClient;
+
+    // The helper is only called for envs with a views contract, so we resolve
+    // exactly two values — one for chainB, one for chainD.
+    mockedHelper.mockResolvedValueOnce(111n).mockResolvedValueOnce(222n);
+
+    const result = await getUserVotingPowers(client, {
+      governanceToken: "WELL",
+      userAddress: USER,
+      snapshotTimestamp: 1_700_000_000,
+    });
+
+    expect(mockedHelper).toHaveBeenCalledTimes(2);
+    expect(validReadB).toHaveBeenCalledWith([USER], { blockNumber: 111n });
+    expect(validReadD).toHaveBeenCalledWith([USER], { blockNumber: 222n });
+    expect(result.map((r) => r.chainId)).toEqual([8453, 10]);
   });
 });

--- a/src/actions/governance/getUserVotingPowers.test.ts
+++ b/src/actions/governance/getUserVotingPowers.test.ts
@@ -25,9 +25,9 @@ const mockedHelper = vi.mocked(getBlockNumberAtTimestamp);
 describe("Testing user voting powers", () => {
   // Only iterate environments where the queried governance token is configured
   // AND the governance views contract is deployed — calling
-  // getUserVotingPowers({governanceToken: "WELL"}) on a chain that holds WELL but
-  // has no views contract (e.g. Ethereum pre-MIP-X56) correctly returns [],
-  // which would fail the `length > 0` assertion.
+  // getUserVotingPowers({governanceToken: "WELL"}) on a chain that holds WELL
+  // but is not the governance hub (e.g. Ethereum) correctly returns [], which
+  // would fail the `length > 0` assertion.
   Object.entries(testClient.environments)
     .filter(([, environment]) => {
       const custom = environment.custom as
@@ -182,5 +182,37 @@ describe("getUserVotingPowers — snapshotTimestamp", () => {
     expect(mockedHelper).not.toHaveBeenCalled();
     expect(reads.chainA).toHaveBeenCalledWith([USER], { blockNumber: 42n });
     expect(reads.chainB).toHaveBeenCalledWith([USER], { blockNumber: 42n });
+  });
+
+  test("environments without a views contract are excluded from results", async () => {
+    const noViewsRead = vi.fn();
+    const validRead = vi.fn(async () => ZERO_USER_VOTES);
+
+    const client = {
+      environments: {
+        chainNoViews: {
+          chainId: 1,
+          custom: { governance: { token: "WELL" } },
+          contracts: {},
+        },
+        chainValid: {
+          chainId: 8453,
+          custom: { governance: { token: "WELL" } },
+          contracts: {
+            views: { read: { getUserVotingPower: validRead } },
+          },
+        },
+      },
+    } as unknown as MoonwellClient;
+
+    const result = await getUserVotingPowers(client, {
+      governanceToken: "WELL",
+      userAddress: USER,
+      blockNumber: 42n,
+    });
+
+    expect(noViewsRead).not.toHaveBeenCalled();
+    expect(validRead).toHaveBeenCalledTimes(1);
+    expect(result.map((r) => r.chainId)).toEqual([8453]);
   });
 });

--- a/src/actions/governance/getUserVotingPowers.test.ts
+++ b/src/actions/governance/getUserVotingPowers.test.ts
@@ -23,15 +23,20 @@ const mockedHelper = vi.mocked(getBlockNumberAtTimestamp);
 // ---------------------------------------------------------------------------
 
 describe("Testing user voting powers", () => {
-  // Only iterate environments where the queried governance token is configured —
-  // calling getUserVotingPowers({governanceToken: "WELL"}) on a chain without WELL
-  // governance correctly returns [], which would fail the `length > 0` assertion.
+  // Only iterate environments where the queried governance token is configured
+  // AND the governance views contract is deployed — calling
+  // getUserVotingPowers({governanceToken: "WELL"}) on a chain that holds WELL but
+  // has no views contract (e.g. Ethereum pre-MIP-X56) correctly returns [],
+  // which would fail the `length > 0` assertion.
   Object.entries(testClient.environments)
     .filter(([, environment]) => {
       const custom = environment.custom as
         | { governance?: { token?: string } }
         | undefined;
-      return custom?.governance?.token === "WELL";
+      const contracts = environment.contracts as { views?: unknown };
+      return (
+        custom?.governance?.token === "WELL" && contracts.views !== undefined
+      );
     })
     .forEach(([networkKey, environment]) => {
       const { chain } = environment;

--- a/src/actions/governance/getUserVotingPowers.ts
+++ b/src/actions/governance/getUserVotingPowers.ts
@@ -49,16 +49,26 @@ export async function getUserVotingPowers<
 
   const environments = getEnvironmentsFromArgs(client, args);
 
-  const tokenEnvironments = environments.filter(
-    (env) =>
+  // Pair each governance-token-holding environment with its non-optional views
+  // contract. A chain may hold the governance token (e.g. Ethereum holds xWELL)
+  // but not have a views contract deployed; voting reads happen on the hub
+  // chain. Excluding the no-views case here lets downstream code call
+  // `views.read.getUserVotingPower` without optional chaining.
+  const tokenEnvironments = environments.flatMap((env) => {
+    const views = env.contracts.views;
+    if (
       env.custom?.governance?.token === governanceToken &&
-      env.contracts.views !== undefined,
-  );
+      views !== undefined
+    ) {
+      return [{ env, views }];
+    }
+    return [];
+  });
 
   const perChainBlockNumbers =
     snapshotTimestamp !== undefined
       ? await Promise.all(
-          tokenEnvironments.map((env) =>
+          tokenEnvironments.map(({ env }) =>
             getBlockNumberAtTimestamp(
               env.publicClient,
               BigInt(snapshotTimestamp),
@@ -67,23 +77,19 @@ export async function getUserVotingPowers<
         )
       : undefined;
 
-  const environmentsUserVotingPowers = await Promise.all(
-    tokenEnvironments.map((environment, index) => {
+  const resolvedVotingPowers = await Promise.all(
+    tokenEnvironments.map(async ({ env, views }, index) => {
       const blockForChain = perChainBlockNumbers
         ? perChainBlockNumbers[index]
         : blockNumber;
-      return environment.contracts.views?.read.getUserVotingPower(
-        [userAddress],
-        {
-          blockNumber: blockForChain,
-        },
-      );
+      const votingPowers = await views.read.getUserVotingPower([userAddress], {
+        blockNumber: blockForChain,
+      });
+      return { env, votingPowers };
     }),
   );
 
-  return tokenEnvironments.map((environment, index) => {
-    const votingPowers = environmentsUserVotingPowers[index]!;
-
+  return resolvedVotingPowers.map(({ env: environment, votingPowers }) => {
     return {
       chainId: environment.chainId,
 

--- a/src/actions/governance/getUserVotingPowers.ts
+++ b/src/actions/governance/getUserVotingPowers.ts
@@ -9,6 +9,8 @@ import type { OptionalNetworkParameterType } from "../../common/types.js";
 import type { Chain, GovernanceToken } from "../../environments/index.js";
 import type { UserVotingPowers } from "../../types/userVotingPowers.js";
 
+const warnedNoViewsEnvs = new Set<string>();
+
 export type GetUserVotingPowersParameters<
   environments,
   network extends Chain | undefined,
@@ -49,20 +51,25 @@ export async function getUserVotingPowers<
 
   const environments = getEnvironmentsFromArgs(client, args);
 
-  // Pair each governance-token-holding environment with its non-optional views
-  // contract. A chain may hold the governance token (e.g. Ethereum holds xWELL)
-  // but not have a views contract deployed; voting reads happen on the hub
-  // chain. Excluding the no-views case here lets downstream code call
-  // `views.read.getUserVotingPower` without optional chaining.
+  // A chain can hold a governance token without deploying a views contract
+  // (voting reads run on the hub). Skipping the no-views case here lets the
+  // read site below call views.read.getUserVotingPower directly.
   const tokenEnvironments = environments.flatMap((env) => {
-    const views = env.contracts.views;
-    if (
-      env.custom?.governance?.token === governanceToken &&
-      views !== undefined
-    ) {
-      return [{ env, views }];
+    if (env.custom?.governance?.token !== governanceToken) {
+      return [];
     }
-    return [];
+    const views = env.contracts.views;
+    if (views === undefined) {
+      const key = `${env.chainId}:${governanceToken}`;
+      if (!warnedNoViewsEnvs.has(key)) {
+        warnedNoViewsEnvs.add(key);
+        console.warn(
+          `[moonwell-sdk] getUserVotingPowers: skipping chainId=${env.chainId} for governanceToken=${governanceToken} — environment holds the token but has no views contract.`,
+        );
+      }
+      return [];
+    }
+    return [{ env, views }];
   });
 
   const perChainBlockNumbers =

--- a/src/actions/governance/getUserVotingPowers.ts
+++ b/src/actions/governance/getUserVotingPowers.ts
@@ -50,7 +50,9 @@ export async function getUserVotingPowers<
   const environments = getEnvironmentsFromArgs(client, args);
 
   const tokenEnvironments = environments.filter(
-    (env) => env.custom?.governance?.token === governanceToken,
+    (env) =>
+      env.custom?.governance?.token === governanceToken &&
+      env.contracts.views !== undefined,
   );
 
   const perChainBlockNumbers =

--- a/src/environments/definitions/ethereum/contracts.ts
+++ b/src/environments/definitions/ethereum/contracts.ts
@@ -4,14 +4,7 @@ import { tokens } from "./tokens.js";
 export const contracts = createContractsConfig({
   tokens,
   contracts: {
-    // `governanceToken` is required for the WELL transfer flow's chain
-    // resolution. `stakingToken` is intentionally omitted while Ethereum
-    // staking is deferred (no CoreViews-equivalent deployed) — the frontend's
-    // stake-page chain picker and `/stake/[network]` route both gate on
-    // `contracts.stakingToken`, so leaving it absent hides Ethereum from the
-    // staking UI without any frontend filter. Restore as `stakingToken:
-    // "stkWELL"` (token already declared in `tokens.ts`) once the contract
-    // ships.
+    // `stakingToken` is intentionally omitted until Ethereum staking contracts ship.
     governanceToken: "WELL",
   },
 });

--- a/src/environments/definitions/ethereum/contracts.ts
+++ b/src/environments/definitions/ethereum/contracts.ts
@@ -1,0 +1,13 @@
+import { createContractsConfig } from "../../types/config.js";
+import { tokens } from "./tokens.js";
+
+export const contracts = createContractsConfig({
+  tokens,
+  contracts: {
+    // `governanceToken` + `stakingToken` are how the frontend's stake-page
+    // chain picker and `getStakingInfo` / `getUserStakingInfo` discover that
+    // Ethereum supports staking. Token addresses live in `tokens.ts`.
+    governanceToken: "WELL",
+    stakingToken: "stkWELL",
+  },
+});

--- a/src/environments/definitions/ethereum/contracts.ts
+++ b/src/environments/definitions/ethereum/contracts.ts
@@ -4,10 +4,14 @@ import { tokens } from "./tokens.js";
 export const contracts = createContractsConfig({
   tokens,
   contracts: {
-    // `governanceToken` + `stakingToken` are how the frontend's stake-page
-    // chain picker and `getStakingInfo` / `getUserStakingInfo` discover that
-    // Ethereum supports staking. Token addresses live in `tokens.ts`.
+    // `governanceToken` is required for the WELL transfer flow's chain
+    // resolution. `stakingToken` is intentionally omitted while Ethereum
+    // staking is deferred (no CoreViews-equivalent deployed) — the frontend's
+    // stake-page chain picker and `/stake/[network]` route both gate on
+    // `contracts.stakingToken`, so leaving it absent hides Ethereum from the
+    // staking UI without any frontend filter. Restore as `stakingToken:
+    // "stkWELL"` (token already declared in `tokens.ts`) once the contract
+    // ships.
     governanceToken: "WELL",
-    stakingToken: "stkWELL",
   },
 });

--- a/src/environments/definitions/ethereum/custom.ts
+++ b/src/environments/definitions/ethereum/custom.ts
@@ -1,15 +1,15 @@
 import { createCustomConfig } from "../../types/config.js";
 
 export const custom = createCustomConfig({
-  // `governance.token: "WELL"` is what the frontend's xWELL bridge modal uses
-  // to discover Ethereum as a WELL-holding chain. `chainIds` is left empty
-  // because Ethereum is not yet the governance hub — that flip happens with
-  // MIP-X56 and is covered by the broader migration plan.
+  // chainIds: [] because Ethereum is currently a satellite (xWELL-holding only),
+  // not the governance hub. When the hub migration lands, populate with the
+  // satellite chain IDs (see moonbeam/custom.ts).
   governance: {
     token: "WELL",
     chainIds: [],
   },
   wormhole: {
     chainId: 2,
+    tokenBridge: { address: "0x3ee18B2214AFF97000D974cf647E654bB5f1d8A8" },
   },
 });

--- a/src/environments/definitions/ethereum/custom.ts
+++ b/src/environments/definitions/ethereum/custom.ts
@@ -1,0 +1,15 @@
+import { createCustomConfig } from "../../types/config.js";
+
+export const custom = createCustomConfig({
+  // `governance.token: "WELL"` is what the frontend's xWELL bridge modal uses
+  // to discover Ethereum as a WELL-holding chain. `chainIds` is left empty
+  // because Ethereum is not yet the governance hub — that flip happens with
+  // MIP-X56 and is covered by the broader migration plan.
+  governance: {
+    token: "WELL",
+    chainIds: [],
+  },
+  wormhole: {
+    chainId: 2,
+  },
+});

--- a/src/environments/definitions/ethereum/custom.ts
+++ b/src/environments/definitions/ethereum/custom.ts
@@ -12,4 +12,7 @@ export const custom = createCustomConfig({
     chainId: 2,
     tokenBridge: { address: "0x3ee18B2214AFF97000D974cf647E654bB5f1d8A8" },
   },
+  xWELL: {
+    bridgeAdapter: { address: "0x734AbBCe07679C9A6B4Fe3bC16325e028fA6DbB7" },
+  },
 });

--- a/src/environments/definitions/ethereum/custom.ts
+++ b/src/environments/definitions/ethereum/custom.ts
@@ -1,9 +1,6 @@
 import { createCustomConfig } from "../../types/config.js";
 
 export const custom = createCustomConfig({
-  // chainIds: [] because Ethereum is currently a satellite (xWELL-holding only),
-  // not the governance hub. When the hub migration lands, populate with the
-  // satellite chain IDs (see moonbeam/custom.ts).
   governance: {
     token: "WELL",
     chainIds: [],

--- a/src/environments/definitions/ethereum/environment.test.ts
+++ b/src/environments/definitions/ethereum/environment.test.ts
@@ -27,4 +27,10 @@ describe("ethereum environment invariants", () => {
       "0xA88594D404727625A9437C3f886C7643872296AE",
     );
   });
+
+  test("xWELL bridge adapter matches MIP-X55", () => {
+    expect(custom.xWELL.bridgeAdapter.address).toBe(
+      "0x734AbBCe07679C9A6B4Fe3bC16325e028fA6DbB7",
+    );
+  });
 });

--- a/src/environments/definitions/ethereum/environment.test.ts
+++ b/src/environments/definitions/ethereum/environment.test.ts
@@ -1,11 +1,10 @@
 import { describe, expect, test } from "vitest";
-import { custom } from "./custom.js";
 import { createEnvironment, ethereum } from "./environment.js";
-import { tokens } from "./tokens.js";
 
-// Locks the four invariants the WELL-to-Ethereum bridge relies on so silent
+// Locks the invariants the WELL-to-Ethereum bridge relies on so silent
 // regressions (e.g. someone bumping viem and `testnet` flipping back to
-// `undefined`) get caught at unit-test time rather than in the frontend.
+// `undefined`, or `custom: custom` being reset to `custom: {}` in
+// environment.ts) get caught at unit-test time rather than in the frontend.
 describe("ethereum environment invariants", () => {
   test("chain.testnet is strictly false", () => {
     expect(ethereum.testnet).toBe(false);
@@ -14,23 +13,24 @@ describe("ethereum environment invariants", () => {
     expect(env.chain.testnet).toBe(false);
   });
 
-  test("governance token is WELL", () => {
-    expect(custom.governance.token).toBe("WELL");
-  });
+  test("custom config flows through createEnvironment", () => {
+    const env = createEnvironment();
 
-  test("wormhole chainId is 2 (Ethereum mainnet)", () => {
-    expect(custom.wormhole.chainId).toBe(2);
-  });
-
-  test("WELL token address matches the canonical xWELL OFT", () => {
-    expect(tokens.WELL.address).toBe(
-      "0xA88594D404727625A9437C3f886C7643872296AE",
+    expect(env.custom.governance.token).toBe("WELL");
+    expect(env.custom.wormhole.chainId).toBe(2);
+    expect(env.custom.wormhole.tokenBridge.address).toBe(
+      "0x3ee18B2214AFF97000D974cf647E654bB5f1d8A8",
+    );
+    expect(env.custom.xWELL.bridgeAdapter.address).toBe(
+      "0x734AbBCe07679C9A6B4Fe3bC16325e028fA6DbB7",
     );
   });
 
-  test("xWELL bridge adapter matches MIP-X55", () => {
-    expect(custom.xWELL.bridgeAdapter.address).toBe(
-      "0x734AbBCe07679C9A6B4Fe3bC16325e028fA6DbB7",
+  test("WELL token address matches the canonical xWELL OFT", () => {
+    const env = createEnvironment();
+
+    expect(env.config.tokens.WELL.address).toBe(
+      "0xA88594D404727625A9437C3f886C7643872296AE",
     );
   });
 });

--- a/src/environments/definitions/ethereum/environment.test.ts
+++ b/src/environments/definitions/ethereum/environment.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "vitest";
+import { custom } from "./custom.js";
+import { createEnvironment, ethereum } from "./environment.js";
+import { tokens } from "./tokens.js";
+
+// Locks the four invariants the WELL-to-Ethereum bridge relies on so silent
+// regressions (e.g. someone bumping viem and `testnet` flipping back to
+// `undefined`) get caught at unit-test time rather than in the frontend.
+describe("ethereum environment invariants", () => {
+  test("chain.testnet is strictly false", () => {
+    expect(ethereum.testnet).toBe(false);
+
+    const env = createEnvironment();
+    expect(env.chain.testnet).toBe(false);
+  });
+
+  test("governance token is WELL", () => {
+    expect(custom.governance.token).toBe("WELL");
+  });
+
+  test("wormhole chainId is 2 (Ethereum mainnet)", () => {
+    expect(custom.wormhole.chainId).toBe(2);
+  });
+
+  test("WELL token address matches the canonical xWELL OFT", () => {
+    expect(tokens.WELL.address).toBe(
+      "0xA88594D404727625A9437C3f886C7643872296AE",
+    );
+  });
+});

--- a/src/environments/definitions/ethereum/environment.test.ts
+++ b/src/environments/definitions/ethereum/environment.test.ts
@@ -1,4 +1,6 @@
+import { base, mainnet, moonbeam, optimism } from "viem/chains";
 import { describe, expect, test } from "vitest";
+import { GovernanceTokensConfig } from "../governance.js";
 import { createEnvironment, ethereum } from "./environment.js";
 
 // Locks the invariants the WELL-to-Ethereum bridge relies on so silent
@@ -31,6 +33,23 @@ describe("ethereum environment invariants", () => {
 
     expect(env.config.tokens.WELL.address).toBe(
       "0xA88594D404727625A9437C3f886C7643872296AE",
+    );
+  });
+
+  test("default indexer URLs are wired when createEnvironment is called with no args", () => {
+    const env = createEnvironment();
+
+    expect(env.lunarIndexerUrl).toBe(
+      "https://lunar-services-worker.moonwell.workers.dev",
+    );
+    expect(env.governanceIndexerUrl).toBe(
+      "https://lunar-services-worker.moonwell.workers.dev",
+    );
+  });
+
+  test("WELL governance token is registered on every chain that holds it", () => {
+    expect(GovernanceTokensConfig.WELL.chainIds).toEqual(
+      expect.arrayContaining([moonbeam.id, base.id, optimism.id, mainnet.id]),
     );
   });
 });

--- a/src/environments/definitions/ethereum/environment.ts
+++ b/src/environments/definitions/ethereum/environment.ts
@@ -4,17 +4,21 @@ import {
   type Environment,
   createEnvironmentConfig,
 } from "../../types/config.js";
+import { custom } from "./custom.js";
 import { tokens } from "./tokens.js";
 
 const createEnvironment = (
   rpcUrls?: string[],
   governanceIndexerUrl?: string,
-): Environment<typeof tokens, {}, {}, {}, {}> =>
+): Environment<typeof tokens, {}, {}, {}, typeof custom> =>
   createEnvironmentConfig({
     key: "ethereum",
     name: "Ethereum",
     chain: {
       ...ethereum,
+      // viem's `mainnet` chain leaves `testnet` undefined; consumers
+      // (e.g. the bridge modal) check `env.chain.testnet === false` strictly.
+      testnet: false,
       rpcUrls: {
         default: { http: rpcUrls || ["https://rpc.moonwell.fi/main/evm/1"] },
       },
@@ -30,7 +34,7 @@ const createEnvironment = (
     vaults: {},
     morphoMarkets: {},
     contracts: {},
-    custom: {},
-  }) as Environment<typeof tokens, {}, {}, {}, {}>;
+    custom,
+  }) as Environment<typeof tokens, {}, {}, {}, typeof custom>;
 
 export { createEnvironment, ethereum, tokens };

--- a/src/environments/definitions/ethereum/environment.ts
+++ b/src/environments/definitions/ethereum/environment.ts
@@ -4,6 +4,7 @@ import {
   type Environment,
   createEnvironmentConfig,
 } from "../../types/config.js";
+import { contracts } from "./contracts.js";
 import { custom } from "./custom.js";
 import { tokens } from "./tokens.js";
 
@@ -14,7 +15,7 @@ const ethereum = defineChain({ ...mainnet, testnet: false });
 const createEnvironment = (
   rpcUrls?: string[],
   governanceIndexerUrl?: string,
-): Environment<typeof tokens, {}, {}, {}, typeof custom> =>
+): Environment<typeof tokens, {}, {}, typeof contracts, typeof custom> =>
   createEnvironmentConfig({
     key: "ethereum",
     name: "Ethereum",
@@ -34,8 +35,8 @@ const createEnvironment = (
     markets: {},
     vaults: {},
     morphoMarkets: {},
-    contracts: {},
+    contracts,
     custom,
-  }) as Environment<typeof tokens, {}, {}, {}, typeof custom>;
+  }) as Environment<typeof tokens, {}, {}, typeof contracts, typeof custom>;
 
 export { createEnvironment, ethereum, tokens };

--- a/src/environments/definitions/ethereum/environment.ts
+++ b/src/environments/definitions/ethereum/environment.ts
@@ -15,6 +15,7 @@ const ethereum = defineChain({ ...mainnet, testnet: false });
 const createEnvironment = (
   rpcUrls?: string[],
   governanceIndexerUrl?: string,
+  lunarIndexerUrl?: string,
 ): Environment<typeof tokens, {}, {}, typeof contracts, typeof custom> =>
   createEnvironmentConfig({
     key: "ethereum",
@@ -31,6 +32,8 @@ const createEnvironment = (
     governanceIndexerUrl:
       governanceIndexerUrl ||
       "https://lunar-services-worker.moonwell.workers.dev",
+    lunarIndexerUrl:
+      lunarIndexerUrl || "https://lunar-services-worker.moonwell.workers.dev",
     tokens,
     markets: {},
     vaults: {},

--- a/src/environments/definitions/ethereum/environment.ts
+++ b/src/environments/definitions/ethereum/environment.ts
@@ -1,11 +1,15 @@
-import { http, fallback } from "viem";
-import { mainnet as ethereum } from "viem/chains";
+import { http, defineChain, fallback } from "viem";
+import { mainnet } from "viem/chains";
 import {
   type Environment,
   createEnvironmentConfig,
 } from "../../types/config.js";
 import { custom } from "./custom.js";
 import { tokens } from "./tokens.js";
+
+// viem's `mainnet` chain leaves `testnet` undefined; consumers
+// (e.g. the bridge modal) check `env.chain.testnet === false` strictly.
+const ethereum = defineChain({ ...mainnet, testnet: false });
 
 const createEnvironment = (
   rpcUrls?: string[],
@@ -16,9 +20,6 @@ const createEnvironment = (
     name: "Ethereum",
     chain: {
       ...ethereum,
-      // viem's `mainnet` chain leaves `testnet` undefined; consumers
-      // (e.g. the bridge modal) check `env.chain.testnet === false` strictly.
-      testnet: false,
       rpcUrls: {
         default: { http: rpcUrls || ["https://rpc.moonwell.fi/main/evm/1"] },
       },

--- a/src/environments/definitions/ethereum/tokens.ts
+++ b/src/environments/definitions/ethereum/tokens.ts
@@ -14,4 +14,10 @@ export const tokens = createTokenConfig({
     name: "USD Coin",
     symbol: "USDC",
   },
+  WELL: {
+    address: "0xA88594D404727625A9437C3f886C7643872296AE",
+    decimals: 18,
+    name: "WELL",
+    symbol: "WELL",
+  },
 });

--- a/src/environments/definitions/ethereum/tokens.ts
+++ b/src/environments/definitions/ethereum/tokens.ts
@@ -20,4 +20,10 @@ export const tokens = createTokenConfig({
     name: "Moonwell",
     symbol: "WELL",
   },
+  stkWELL: {
+    address: "0xb3a9E0DCf37658a48aa9f018C44f90378ddD4357",
+    decimals: 18,
+    name: "Moonwell Staked WELL",
+    symbol: "stkWELL",
+  },
 });

--- a/src/environments/definitions/ethereum/tokens.ts
+++ b/src/environments/definitions/ethereum/tokens.ts
@@ -17,7 +17,7 @@ export const tokens = createTokenConfig({
   WELL: {
     address: "0xA88594D404727625A9437C3f886C7643872296AE",
     decimals: 18,
-    name: "WELL",
+    name: "Moonwell",
     symbol: "WELL",
   },
 });

--- a/src/environments/definitions/governance.ts
+++ b/src/environments/definitions/governance.ts
@@ -1,4 +1,4 @@
-import { base, moonbeam, moonriver, optimism } from "viem/chains";
+import { base, mainnet, moonbeam, moonriver, optimism } from "viem/chains";
 
 export interface GovernanceTokenInfo {
   id: string;
@@ -30,7 +30,7 @@ export const GovernanceTokensConfig = createGovernanceTokensConfig({
     id: "WELL",
     symbol: "WELL",
     name: "WELL",
-    chainIds: [moonbeam.id, base.id, optimism.id] as number[],
+    chainIds: [moonbeam.id, base.id, optimism.id, mainnet.id] as number[],
     testnet: false,
   },
   MFAM: {

--- a/test/vitest.config.ts
+++ b/test/vitest.config.ts
@@ -42,6 +42,7 @@ export default defineConfig({
       "src/actions/core/user-positions/getUserPositionSnapshots.test.ts",
       "src/client/createMoonwellClient.test.ts",
       "src/common/getBlockNumberAtTimestamp.test.ts",
+      "src/environments/definitions/ethereum/environment.test.ts",
     ],
     setupFiles: [join(__dirname, "./setup.ts")],
     hookTimeout: 60_000,


### PR DESCRIPTION
## Summary

Wires Ethereum mainnet into the SDK as the fifth WELL-holding chain. Unblocks the frontend's `/transfer` UI for Ethereum bridge flows and pre-wires governance reads to light up once the CoreViews-equivalent contract ships.

Per **MIP-X55** (Moonbeam proposal #164, EXECUTED), the satellite-chain xWELL adapters now recognize the Ethereum `WormholeBridgeAdapter` at `0x734AbBCe07679C9A6B4Fe3bC16325e028fA6DbB7`, so bridge transfers in/out of Ethereum are live on-chain. This PR brings the SDK in line.

## What's in

### New `ethereum` environment (`src/environments/definitions/ethereum/`)

- **Chain** — viem's `mainnet` wrapped in `defineChain({ ...mainnet, testnet: false })` so consumers can rely on a strict `chain.testnet === false` check (viem leaves it `undefined` by default; the frontend's bridge modal does `=== false`).
- **Tokens** — WELL (xWELL OFT at `0xA88594D404727625A9437C3f886C7643872296AE`, name `"Moonwell"` for parity with Base) and stkWELL.
- **`custom.governance`** — `{ token: "WELL", chainIds: [] }`. `chainIds` left empty because Ethereum is a satellite today (xWELL-holding only), not the governance hub.
- **`custom.wormhole`** — `chainId: 2`, `tokenBridge.address: "0x3ee18B…d8A8"` (canonical Wormhole portal on Ethereum).
- **`custom.xWELL.bridgeAdapter.address`** — `0x734AbBCe…dbB7` (the Ethereum adapter MIP-X55 names).
- **`contracts`** — only `governanceToken: "WELL"`. `stakingToken` is intentionally omitted while Ethereum staking is deferred (no CoreViews-equivalent deployed) — frontend pickers and the `/stake/[network]` route gate on `contracts.stakingToken`, so leaving it out keeps Ethereum out of the staking UI without any frontend filter. The matching `stkWELL` token is already declared in `tokens.ts` so the field can be restored as a one-line change once the contract ships.
- **`lunarIndexerUrl`** — set to `https://lunar-services-worker.moonwell.workers.dev` so `getCirculatingSupplySnapshots({ chainId: 1 })` reads from the same indexer Base/Optimism/Moonbeam use.
- **`governanceIndexerUrl`** — same URL, separate field, used by other governance reads.

### `getUserVotingPowers` refactor (`src/actions/governance/getUserVotingPowers.ts`)

Previously the action mapped every governance-token-holding environment to `env.contracts.views?.read.getUserVotingPower(...)` and then later did `votingPowers!.claimsVotes…`, which crashes whenever an environment doesn't have a views contract (Ethereum's `contracts: {}`).

The refactor pairs each environment with its non-optional `views` contract up front via `flatMap`, so:

- Environments without a views contract are filtered out before any read.
- Downstream code can call `views.read.getUserVotingPower([address], { blockNumber })` directly — no optional chaining, no non-null assertions.
- The matching test in `getUserVotingPowers.test.ts` was tightened to filter test environments by `views !== undefined` so it doesn't iterate Ethereum (which would return `[]`).

### WELL governance chain registration (`src/environments/definitions/governance.ts`)

Added `mainnet` to `WELL.chainIds` so `getUserVotingPowers({ governanceToken: "WELL" })` knows to query Ethereum once a views contract exists there. Today this is a no-op because of the views filter above, but it pre-wires the SDK for the post-CoreViews flip.

### Tests

- `src/environments/definitions/ethereum/environment.test.ts` (new) — locks in the four invariants the frontend bridge UI relies on: `chain.testnet === false`, `custom.governance.token === "WELL"`, `custom.wormhole.chainId === 2`, `tokens.WELL.address`, and `custom.xWELL.bridgeAdapter.address` (the address MIP-X55 names).
- `getUserVotingPowers.test.ts` — adds coverage for the views-filter (environments without a views contract are excluded from results) and updates the existing integration tests to skip Ethereum since it has no views contract today.

## Consumer impact

- **Frontend transfer flow** — Ethereum can be source or destination on `/transfer` once the patch is applied (the frontend ships an SDK overlay via `patch-package` until this lands as a release).
- **Staking** — `getStakingInfo` / `getUserStakingInfo` for `chainId: 1` returns nothing because Ethereum has no views or staking contracts. Frontend gates on `contracts.stakingToken` so the chain is invisible in stake UIs; behavior matches that.
- **Voting** — `getUserVotingPowers({ governanceToken: "WELL" })` already filters out Ethereum until `contracts.views` is populated. No-op for callers.
- **Circulating supply** — `getCirculatingSupplySnapshots({ chainId: 1 })` now hits the Lunar Indexer at `lunar-services-worker.moonwell.workers.dev` and returns the live snapshot stream the indexer is already serving.

## Follow-ups (when CoreViews ships on Ethereum)

1. Add the views contract address + `stkWELL` staking address to `src/environments/definitions/ethereum/contracts.ts` (already-declared `governanceToken` and new `stakingToken: "stkWELL"` + `views` entry).
2. No frontend changes required — the existing `/stake/[network]` filter and `useUserVotingPowers` query both light up automatically once `contracts.views` and `contracts.stakingToken` exist.

## Verification

- `pnpm tsc --noEmit` — clean
- `pnpm test` — full suite green (418/418), including the new environment-invariants test and the views-filter test
- `pnpm build` — CJS/ESM/types outputs match consumer expectations (verified by the frontend's `patch-package` overlay applying cleanly)