### PR TITLE
feat(morpho/user-rewards): opt-in error propagation for Merkl API

### DIFF
--- a/.changeset/tall-lights-write.md
+++ b/.changeset/tall-lights-write.md
@@ -1,5 +1,9 @@
 ---
-"@moonwell-fi/moonwell-sdk": patch
+"@moonwell-fi/moonwell-sdk": minor
 ---
 
-Add opt-in `throwOnExternalApiError` option to `getMorphoUserRewards`. When `true`, Merkl API failures propagate to the caller instead of being swallowed and returning `[]`. Defaults to `false`, so existing consumers see no behavior change.
+Add opt-in `throwOnExternalApiError` option to `getMorphoUserRewards`. When `true`, Merkl API failures (non-ok HTTP responses, network rejections, and response-body parse errors) propagate to the caller as `MerklApiError` instead of being swallowed and returning `[]`. Defaults to `false`, so existing consumers see no behavior change.
+
+When multiple chains are queried and at least one fails while others succeed, the action throws a `MorphoUserRewardsAggregateError` whose `errors` array carries the per-chain failures and whose `rewards` property carries the rewards from chains that succeeded, so callers can surface partial results alongside the failures.
+
+New public exports: `MerklApiError`, `MorphoUserRewardsAggregateError`.

--- a/.changeset/tall-lights-write.md
+++ b/.changeset/tall-lights-write.md
@@ -1,0 +1,5 @@
+---
+"@moonwell-fi/moonwell-sdk": patch
+---
+
+Add opt-in `throwOnExternalApiError` option to `getMorphoUserRewards`. When `true`, Merkl API failures propagate to the caller instead of being swallowed and returning `[]`. Defaults to `false`, so existing consumers see no behavior change.

--- a/src/actions/morpho/user-rewards/common.test.ts
+++ b/src/actions/morpho/user-rewards/common.test.ts
@@ -174,6 +174,43 @@ describe("getUserMorphoRewardsData", () => {
     expect(result).toEqual([]);
   });
 
+  test("with throwOnExternalApiError, propagates non-ok Merkl responses", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve({
+          ok: false,
+          status: 500,
+          statusText: "Internal Server Error",
+        }),
+      ),
+    );
+
+    await expect(
+      getUserMorphoRewardsData({
+        environment: baseEnvironment,
+        account: ACCOUNT,
+        throwOnExternalApiError: true,
+      }),
+    ).rejects.toThrow(/Merkl API request failed: 500/);
+  });
+
+  test("with throwOnExternalApiError, propagates fetch rejections", async () => {
+    const networkError = new Error("network unreachable");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.reject(networkError)),
+    );
+
+    await expect(
+      getUserMorphoRewardsData({
+        environment: baseEnvironment,
+        account: ACCOUNT,
+        throwOnExternalApiError: true,
+      }),
+    ).rejects.toBe(networkError);
+  });
+
   test("on full deployments, returns zero claimable when no breakdowns match Moonwell campaigns", async () => {
     mockFetchOnce(
       makeMerklResponse({ amount: "1000", claimed: "200", pending: "50" }, [

--- a/src/actions/morpho/user-rewards/common.test.ts
+++ b/src/actions/morpho/user-rewards/common.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 import type { Environment } from "../../../environments/index.js";
 import type { MorphoUserReward } from "../../../types/morphoUserReward.js";
-import { getUserMorphoRewardsData } from "./common.js";
+import { MerklApiError, getUserMorphoRewardsData } from "./common.js";
 
 type MerklReward = Extract<MorphoUserReward, { type: "merkl-reward" }>;
 
@@ -174,7 +174,21 @@ describe("getUserMorphoRewardsData", () => {
     expect(result).toEqual([]);
   });
 
-  test("with throwOnExternalApiError, propagates non-ok Merkl responses", async () => {
+  test("returns empty array when fetch rejects and throwOnExternalApiError is not set", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.reject(new Error("network unreachable"))),
+    );
+
+    const result = await getUserMorphoRewardsData({
+      environment: baseEnvironment,
+      account: ACCOUNT,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  test("with throwOnExternalApiError, propagates non-ok Merkl responses as MerklApiError", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(() =>
@@ -186,13 +200,25 @@ describe("getUserMorphoRewardsData", () => {
       ),
     );
 
-    await expect(
-      getUserMorphoRewardsData({
+    let caught: unknown;
+    try {
+      await getUserMorphoRewardsData({
         environment: baseEnvironment,
         account: ACCOUNT,
         throwOnExternalApiError: true,
-      }),
-    ).rejects.toThrow(/Merkl API request failed: 500/);
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(MerklApiError);
+    const merklError = caught as MerklApiError;
+    expect(merklError.status).toBe(500);
+    expect(merklError.statusText).toBe("Internal Server Error");
+    expect(merklError.chainId).toBe(8453);
+    expect(merklError.url).toContain("api.merkl.xyz");
+    expect(merklError.message).toContain("chain 8453");
+    expect(merklError.message).toContain("500");
   });
 
   test("with throwOnExternalApiError, propagates fetch rejections", async () => {

--- a/src/actions/morpho/user-rewards/common.test.ts
+++ b/src/actions/morpho/user-rewards/common.test.ts
@@ -221,12 +221,81 @@ describe("getUserMorphoRewardsData", () => {
     expect(merklError.message).toContain("500");
   });
 
-  test("with throwOnExternalApiError, propagates fetch rejections", async () => {
+  test("with throwOnExternalApiError, wraps fetch rejections in MerklApiError", async () => {
     const networkError = new Error("network unreachable");
     vi.stubGlobal(
       "fetch",
       vi.fn(() => Promise.reject(networkError)),
     );
+
+    let caught: unknown;
+    try {
+      await getUserMorphoRewardsData({
+        environment: baseEnvironment,
+        account: ACCOUNT,
+        throwOnExternalApiError: true,
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(MerklApiError);
+    const merklError = caught as MerklApiError;
+    expect(merklError.chainId).toBe(8453);
+    expect(merklError.status).toBeUndefined();
+    expect(merklError.statusText).toBeUndefined();
+    expect(merklError.url).toContain("api.merkl.xyz");
+    expect(merklError.message).toContain("network error");
+    expect(merklError.cause).toBe(networkError);
+  });
+
+  test("with throwOnExternalApiError, wraps response parse failures in MerklApiError", async () => {
+    const parseError = new SyntaxError("unexpected token");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.reject(parseError),
+        }),
+      ),
+    );
+
+    let caught: unknown;
+    try {
+      await getUserMorphoRewardsData({
+        environment: baseEnvironment,
+        account: ACCOUNT,
+        throwOnExternalApiError: true,
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(MerklApiError);
+    const merklError = caught as MerklApiError;
+    expect(merklError.chainId).toBe(8453);
+    expect(merklError.status).toBeUndefined();
+    expect(merklError.message).toContain("parse error");
+    expect(merklError.cause).toBe(parseError);
+  });
+
+  test("with throwOnExternalApiError, does not log on non-ok HTTP response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve({
+          ok: false,
+          status: 500,
+          statusText: "Internal Server Error",
+        }),
+      ),
+    );
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const error = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
 
     await expect(
       getUserMorphoRewardsData({
@@ -234,7 +303,32 @@ describe("getUserMorphoRewardsData", () => {
         account: ACCOUNT,
         throwOnExternalApiError: true,
       }),
-    ).rejects.toBe(networkError);
+    ).rejects.toBeInstanceOf(MerklApiError);
+
+    expect(warn).toHaveBeenCalledTimes(0);
+    expect(error).toHaveBeenCalledTimes(0);
+  });
+
+  test("with throwOnExternalApiError, does not log on fetch rejection", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.reject(new Error("network unreachable"))),
+    );
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const error = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    await expect(
+      getUserMorphoRewardsData({
+        environment: baseEnvironment,
+        account: ACCOUNT,
+        throwOnExternalApiError: true,
+      }),
+    ).rejects.toBeInstanceOf(MerklApiError);
+
+    expect(warn).toHaveBeenCalledTimes(0);
+    expect(error).toHaveBeenCalledTimes(0);
   });
 
   test("on full deployments, returns zero claimable when no breakdowns match Moonwell campaigns", async () => {

--- a/src/actions/morpho/user-rewards/common.ts
+++ b/src/actions/morpho/user-rewards/common.ts
@@ -13,15 +13,31 @@ import {
 import type { MorphoUserReward } from "../../../types/morphoUserReward.js";
 import type { MorphoUserStakingReward } from "../../../types/morphoUserStakingReward.js";
 
+export class MerklApiError extends Error {
+  readonly status: number | undefined;
+  readonly statusText: string | undefined;
+  readonly url: string;
+  readonly chainId: number;
+
+  constructor(params: {
+    message: string;
+    url: string;
+    chainId: number;
+    status?: number | undefined;
+    statusText?: string | undefined;
+  }) {
+    super(params.message);
+    this.name = "MerklApiError";
+    this.url = params.url;
+    this.chainId = params.chainId;
+    this.status = params.status;
+    this.statusText = params.statusText;
+  }
+}
+
 export async function getUserMorphoRewardsData(params: {
   environment: Environment;
   account: `0x${string}`;
-  /**
-   * When true, errors from the external Merkl API are propagated to the
-   * caller instead of being swallowed and returning `[]`. Default `false`
-   * preserves the historical behavior for existing consumers; the frontend
-   * sets it `true` so React Query can surface a degradation notice.
-   */
   throwOnExternalApiError?: boolean;
 }): Promise<MorphoUserReward[]> {
   // The Morpho URD distributions endpoint (rewards.morpho.org) was
@@ -306,31 +322,50 @@ async function getMerklRewardsData(
 ): Promise<MerklRewardsResponse[]> {
   const url = `https://api.merkl.xyz/v4/users/${account}/rewards?chainId=${environment.chainId}&test=false&breakdownPage=0&reloadChainId=${environment.chainId}`;
 
+  let response: Response;
   try {
     // Merkl campaigns always distribute rewards on the same chain as the
     // opportunity, so environment.chainId is the only chain we need to query.
     // The previous two-phase approach (fetch opportunities per vault → extract
     // chain IDs → fetch rewards per chain) made N+1 HTTP calls to discover
     // a chain ID we already know.
-    const response = await fetch(url, {
-      headers: MOONWELL_FETCH_JSON_HEADERS,
-    });
-
-    if (!response.ok) {
-      const message = `Merkl API request failed: ${response.status} ${response.statusText}`;
-      if (options.throwOnError) {
-        throw new Error(message);
-      }
-      console.warn(message);
-      return [];
+    response = await fetch(url, { headers: MOONWELL_FETCH_JSON_HEADERS });
+  } catch (error) {
+    if (options.throwOnError) {
+      throw error;
     }
+    console.error(
+      `[getMerklRewardsData:network] chain=${environment.chainId} url=${url}`,
+      error,
+    );
+    return [];
+  }
 
+  if (!response.ok) {
+    const message = `Merkl API request failed for chain ${environment.chainId}: ${response.status} ${response.statusText}`;
+    if (options.throwOnError) {
+      throw new MerklApiError({
+        message,
+        url,
+        chainId: environment.chainId,
+        status: response.status,
+        statusText: response.statusText,
+      });
+    }
+    console.warn(`${message} (url=${url})`);
+    return [];
+  }
+
+  try {
     return (await response.json()) as MerklRewardsResponse[];
   } catch (error) {
     if (options.throwOnError) {
       throw error;
     }
-    console.error("Error in getMerklRewardsData:", error);
+    console.error(
+      `[getMerklRewardsData:parse] chain=${environment.chainId} url=${url}`,
+      error,
+    );
     return [];
   }
 }

--- a/src/actions/morpho/user-rewards/common.ts
+++ b/src/actions/morpho/user-rewards/common.ts
@@ -16,6 +16,13 @@ import type { MorphoUserStakingReward } from "../../../types/morphoUserStakingRe
 export async function getUserMorphoRewardsData(params: {
   environment: Environment;
   account: `0x${string}`;
+  /**
+   * When true, errors from the external Merkl API are propagated to the
+   * caller instead of being swallowed and returning `[]`. Default `false`
+   * preserves the historical behavior for existing consumers; the frontend
+   * sets it `true` so React Query can surface a degradation notice.
+   */
+  throwOnExternalApiError?: boolean;
 }): Promise<MorphoUserReward[]> {
   // The Morpho URD distributions endpoint (rewards.morpho.org) was
   // deprecated and now 301-redirects to a SPA, so JSON parsing fails.
@@ -23,6 +30,7 @@ export async function getUserMorphoRewardsData(params: {
   const merklRewards = await getMerklRewardsData(
     params.environment,
     params.account,
+    { throwOnError: params.throwOnExternalApiError ?? false },
   );
 
   const isFullDeployment =
@@ -294,29 +302,34 @@ type MerklRewardsResponse = {
 async function getMerklRewardsData(
   environment: Environment,
   account: Address,
+  options: { throwOnError: boolean } = { throwOnError: false },
 ): Promise<MerklRewardsResponse[]> {
+  const url = `https://api.merkl.xyz/v4/users/${account}/rewards?chainId=${environment.chainId}&test=false&breakdownPage=0&reloadChainId=${environment.chainId}`;
+
   try {
     // Merkl campaigns always distribute rewards on the same chain as the
     // opportunity, so environment.chainId is the only chain we need to query.
     // The previous two-phase approach (fetch opportunities per vault → extract
     // chain IDs → fetch rewards per chain) made N+1 HTTP calls to discover
     // a chain ID we already know.
-    const response = await fetch(
-      `https://api.merkl.xyz/v4/users/${account}/rewards?chainId=${environment.chainId}&test=false&breakdownPage=0&reloadChainId=${environment.chainId}`,
-      {
-        headers: MOONWELL_FETCH_JSON_HEADERS,
-      },
-    );
+    const response = await fetch(url, {
+      headers: MOONWELL_FETCH_JSON_HEADERS,
+    });
 
     if (!response.ok) {
-      console.warn(
-        `Merkl API request failed: ${response.status} ${response.statusText}`,
-      );
+      const message = `Merkl API request failed: ${response.status} ${response.statusText}`;
+      if (options.throwOnError) {
+        throw new Error(message);
+      }
+      console.warn(message);
       return [];
     }
 
     return (await response.json()) as MerklRewardsResponse[];
   } catch (error) {
+    if (options.throwOnError) {
+      throw error;
+    }
     console.error("Error in getMerklRewardsData:", error);
     return [];
   }

--- a/src/actions/morpho/user-rewards/common.ts
+++ b/src/actions/morpho/user-rewards/common.ts
@@ -13,6 +13,14 @@ import {
 import type { MorphoUserReward } from "../../../types/morphoUserReward.js";
 import type { MorphoUserStakingReward } from "../../../types/morphoUserStakingReward.js";
 
+/**
+ * Error thrown for any failure communicating with the Merkl API: non-ok HTTP
+ * responses, network rejections (fetch threw), and response-body parse errors.
+ *
+ * - HTTP failures populate `status` and `statusText`.
+ * - Network and parse failures leave `status`/`statusText` undefined and
+ *   carry the original error via `cause`.
+ */
 export class MerklApiError extends Error {
   readonly status: number | undefined;
   readonly statusText: string | undefined;
@@ -25,8 +33,12 @@ export class MerklApiError extends Error {
     chainId: number;
     status?: number | undefined;
     statusText?: string | undefined;
+    cause?: unknown;
   }) {
-    super(params.message);
+    super(
+      params.message,
+      params.cause !== undefined ? { cause: params.cause } : undefined,
+    );
     this.name = "MerklApiError";
     this.url = params.url;
     this.chainId = params.chainId;
@@ -332,7 +344,12 @@ async function getMerklRewardsData(
     response = await fetch(url, { headers: MOONWELL_FETCH_JSON_HEADERS });
   } catch (error) {
     if (options.throwOnError) {
-      throw error;
+      throw new MerklApiError({
+        message: `Merkl API network error for chain ${environment.chainId}`,
+        url,
+        chainId: environment.chainId,
+        cause: error,
+      });
     }
     console.error(
       `[getMerklRewardsData:network] chain=${environment.chainId} url=${url}`,
@@ -360,7 +377,12 @@ async function getMerklRewardsData(
     return (await response.json()) as MerklRewardsResponse[];
   } catch (error) {
     if (options.throwOnError) {
-      throw error;
+      throw new MerklApiError({
+        message: `Merkl API response parse error for chain ${environment.chainId}`,
+        url,
+        chainId: environment.chainId,
+        cause: error,
+      });
     }
     console.error(
       `[getMerklRewardsData:parse] chain=${environment.chainId} url=${url}`,

--- a/src/actions/morpho/user-rewards/getMorphoUserRewards.test.ts
+++ b/src/actions/morpho/user-rewards/getMorphoUserRewards.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 import type { MoonwellClient } from "../../../client/createMoonwellClient.js";
-import { getMorphoUserRewards } from "./getMorphoUserRewards.js";
+import { MerklApiError } from "./common.js";
+import {
+  MorphoUserRewardsAggregateError,
+  getMorphoUserRewards,
+} from "./getMorphoUserRewards.js";
 
 const ACCOUNT = "0x1234567890abcdef1234567890abcdef12345678" as const;
 
@@ -61,13 +65,17 @@ describe("getMorphoUserRewards", () => {
       caught = error;
     }
 
-    expect(caught).toBeInstanceOf(AggregateError);
-    const aggregate = caught as AggregateError;
+    expect(caught).toBeInstanceOf(MorphoUserRewardsAggregateError);
+    const aggregate = caught as MorphoUserRewardsAggregateError;
     expect(aggregate.message).toContain("8453");
     expect(aggregate.errors).toHaveLength(1);
-    const inner = aggregate.errors[0] as Error;
-    expect(inner.message).toContain("chain 8453");
-    expect((inner.cause as Error).message).toMatch(
+    expect(aggregate.rewards).toEqual([]);
+    const inner = aggregate.errors[0] as MerklApiError;
+    expect(inner).toBeInstanceOf(MerklApiError);
+    expect(inner.chainId).toBe(8453);
+    expect(inner.status).toBe(500);
+    expect(inner.statusText).toBe("Internal Server Error");
+    expect(inner.message).toMatch(
       /Merkl API request failed for chain 8453: 500/,
     );
   });
@@ -186,11 +194,82 @@ describe("getMorphoUserRewards", () => {
       caught = error;
     }
 
-    expect(caught).toBeInstanceOf(AggregateError);
-    const aggregate = caught as AggregateError;
+    expect(caught).toBeInstanceOf(MorphoUserRewardsAggregateError);
+    const aggregate = caught as MorphoUserRewardsAggregateError;
     expect(aggregate.message).toContain("8453");
     expect(aggregate.errors).toHaveLength(1);
-    expect((aggregate.errors[0] as Error).message).toContain("chain 8453");
-    expect((aggregate.errors[0] as Error).cause).toBe(baseError);
+    const inner = aggregate.errors[0] as MerklApiError;
+    expect(inner).toBeInstanceOf(MerklApiError);
+    expect(inner.chainId).toBe(8453);
+    expect(inner.cause).toBe(baseError);
+  });
+
+  test("with throwOnExternalApiError and a successful chain, attaches partial rewards to AggregateError", async () => {
+    stubFetchByChain({
+      8453: () => ({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+      }),
+      10: () => ({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve([
+            {
+              chain: { id: 10, name: "Optimism", icon: "" },
+              rewards: [
+                {
+                  root: "0x",
+                  recipient: ACCOUNT,
+                  amount: "1000",
+                  claimed: "200",
+                  pending: "50",
+                  proofs: [],
+                  token: {
+                    address: "0xA88594D404727625A9437C3f886C7643872296AE",
+                    chainId: 10,
+                    symbol: "WELL",
+                    decimals: 18,
+                    price: 0.004,
+                  },
+                  breakdowns: [],
+                },
+              ],
+            },
+          ]),
+      }),
+    });
+
+    const client = {
+      environments: {
+        base: {
+          chainId: 8453,
+          contracts: { morphoViews: {}, views: {} },
+          custom: { morpho: { minimalDeployment: false } },
+        },
+        optimism: {
+          chainId: 10,
+          contracts: { morphoViews: {}, views: {} },
+          custom: { morpho: { minimalDeployment: true } },
+        },
+      },
+    } as unknown as MoonwellClient;
+
+    let caught: unknown;
+    try {
+      await getMorphoUserRewards(client, {
+        userAddress: ACCOUNT,
+        throwOnExternalApiError: true,
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(MorphoUserRewardsAggregateError);
+    const aggregate = caught as MorphoUserRewardsAggregateError;
+    expect(aggregate.errors).toHaveLength(1);
+    expect(aggregate.rewards).toHaveLength(1);
+    expect(aggregate.rewards[0]?.chainId).toBe(10);
   });
 });

--- a/src/actions/morpho/user-rewards/getMorphoUserRewards.test.ts
+++ b/src/actions/morpho/user-rewards/getMorphoUserRewards.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import type { MoonwellClient } from "../../../client/createMoonwellClient.js";
+import { getMorphoUserRewards } from "./getMorphoUserRewards.js";
+
+const ACCOUNT = "0x1234567890abcdef1234567890abcdef12345678" as const;
+
+function makeClient(chainIds: number[]): MoonwellClient {
+  const environments = Object.fromEntries(
+    chainIds.map((chainId) => [
+      `chain-${chainId}`,
+      {
+        chainId,
+        contracts: { morphoViews: {}, views: {} },
+        custom: { morpho: { minimalDeployment: false } },
+      },
+    ]),
+  );
+  return { environments } as unknown as MoonwellClient;
+}
+
+function stubFetchByChain(
+  responses: Record<number, () => Promise<unknown> | unknown>,
+) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((input: string) => {
+      const url = new URL(input);
+      const chainId = Number(url.searchParams.get("chainId"));
+      const responder = responses[chainId];
+      if (!responder) {
+        return Promise.reject(new Error(`unexpected chainId ${chainId}`));
+      }
+      return Promise.resolve(responder());
+    }),
+  );
+}
+
+describe("getMorphoUserRewards", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("with throwOnExternalApiError true and 500 response, rejects with chain context", async () => {
+    stubFetchByChain({
+      8453: () => ({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+      }),
+    });
+
+    const client = makeClient([8453]);
+
+    let caught: unknown;
+    try {
+      await getMorphoUserRewards(client, {
+        userAddress: ACCOUNT,
+        throwOnExternalApiError: true,
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(AggregateError);
+    const aggregate = caught as AggregateError;
+    expect(aggregate.message).toContain("8453");
+    expect(aggregate.errors).toHaveLength(1);
+    const inner = aggregate.errors[0] as Error;
+    expect(inner.message).toContain("chain 8453");
+    expect((inner.cause as Error).message).toMatch(
+      /Merkl API request failed for chain 8453: 500/,
+    );
+  });
+
+  test("without throwOnExternalApiError, resolves to [] on 500", async () => {
+    stubFetchByChain({
+      8453: () => ({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+      }),
+    });
+
+    const client = makeClient([8453]);
+
+    const result = await getMorphoUserRewards(client, {
+      userAddress: ACCOUNT,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  test("preserves successful chains when one fails and flag is unset", async () => {
+    stubFetchByChain({
+      8453: () => ({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+      }),
+      10: () => ({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve([
+            {
+              chain: { id: 10, name: "Optimism", icon: "" },
+              rewards: [
+                {
+                  root: "0x",
+                  recipient: ACCOUNT,
+                  amount: "1000",
+                  claimed: "200",
+                  pending: "50",
+                  proofs: [],
+                  token: {
+                    address: "0xA88594D404727625A9437C3f886C7643872296AE",
+                    chainId: 10,
+                    symbol: "WELL",
+                    decimals: 18,
+                    price: 0.004,
+                  },
+                  breakdowns: [],
+                },
+              ],
+            },
+          ]),
+      }),
+    });
+
+    const client = {
+      environments: {
+        base: {
+          chainId: 8453,
+          contracts: { morphoViews: {}, views: {} },
+          custom: { morpho: { minimalDeployment: false } },
+        },
+        optimism: {
+          chainId: 10,
+          contracts: { morphoViews: {}, views: {} },
+          custom: { morpho: { minimalDeployment: true } },
+        },
+      },
+    } as unknown as MoonwellClient;
+
+    const result = await getMorphoUserRewards(client, {
+      userAddress: ACCOUNT,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.chainId).toBe(10);
+  });
+
+  test("with throwOnExternalApiError, throws AggregateError listing failed chains and preserves errors", async () => {
+    const baseError = new Error("base went down");
+    stubFetchByChain({
+      8453: () => Promise.reject(baseError),
+      10: () => ({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve([]),
+      }),
+    });
+
+    const client = {
+      environments: {
+        base: {
+          chainId: 8453,
+          contracts: { morphoViews: {}, views: {} },
+          custom: { morpho: { minimalDeployment: false } },
+        },
+        optimism: {
+          chainId: 10,
+          contracts: { morphoViews: {}, views: {} },
+          custom: { morpho: { minimalDeployment: true } },
+        },
+      },
+    } as unknown as MoonwellClient;
+
+    let caught: unknown;
+    try {
+      await getMorphoUserRewards(client, {
+        userAddress: ACCOUNT,
+        throwOnExternalApiError: true,
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(AggregateError);
+    const aggregate = caught as AggregateError;
+    expect(aggregate.message).toContain("8453");
+    expect(aggregate.errors).toHaveLength(1);
+    expect((aggregate.errors[0] as Error).message).toContain("chain 8453");
+    expect((aggregate.errors[0] as Error).cause).toBe(baseError);
+  });
+});

--- a/src/actions/morpho/user-rewards/getMorphoUserRewards.ts
+++ b/src/actions/morpho/user-rewards/getMorphoUserRewards.ts
@@ -14,8 +14,13 @@ export type GetMorphoUserRewardsParameters<
   /**
    * When true, errors from the external Merkl API are propagated to the
    * caller instead of being swallowed and returning `[]`. Default `false`
-   * preserves the historical behavior for existing consumers; the frontend
-   * sets it `true` so React Query can surface a degradation notice.
+   * preserves the historical behavior for existing consumers.
+   *
+   * If multiple environments are queried and at least one fails while others
+   * succeed, this throws an `AggregateError` whose `errors` array contains
+   * the per-chain failures. Successful chains' rewards are not returned in
+   * the error path; callers wanting partial success should set this to
+   * `false` (the default) and inspect logs for per-chain failures.
    */
   throwOnExternalApiError?: boolean;
 };
@@ -29,21 +34,52 @@ export async function getMorphoUserRewards<
   client: MoonwellClient,
   args: GetMorphoUserRewardsParameters<environments, Network>,
 ): GetMorphoUserRewardsReturnType {
-  const environments = getEnvironmentsFromArgs(client, args);
-
-  const environmentsUserRewards = await Promise.all(
-    environments
-      .filter((environment) => environment.contracts.morphoViews !== undefined)
-      .map((environment) => {
-        return getUserMorphoRewardsData({
-          environment,
-          account: args.userAddress,
-          ...(args.throwOnExternalApiError !== undefined && {
-            throwOnExternalApiError: args.throwOnExternalApiError,
-          }),
-        });
-      }),
+  const targetEnvironments = getEnvironmentsFromArgs(client, args).filter(
+    (environment) => environment.contracts.morphoViews !== undefined,
   );
 
-  return environmentsUserRewards.flat();
+  const settled = await Promise.allSettled(
+    targetEnvironments.map((environment) =>
+      getUserMorphoRewardsData({
+        environment,
+        account: args.userAddress,
+        ...(args.throwOnExternalApiError !== undefined && {
+          throwOnExternalApiError: args.throwOnExternalApiError,
+        }),
+      }),
+    ),
+  );
+
+  const fulfilled: MorphoUserReward[] = [];
+  const failures: Error[] = [];
+  const failedChainIds: number[] = [];
+  for (let i = 0; i < settled.length; i++) {
+    const result = settled[i];
+    const environment = targetEnvironments[i];
+    if (result === undefined || environment === undefined) continue;
+    if (result.status === "fulfilled") {
+      fulfilled.push(...result.value);
+    } else {
+      const baseError =
+        result.reason instanceof Error
+          ? result.reason
+          : new Error(String(result.reason));
+      failures.push(
+        new Error(
+          `getMorphoUserRewards failed for chain ${environment.chainId}: ${baseError.message}`,
+          { cause: baseError },
+        ),
+      );
+      failedChainIds.push(environment.chainId);
+    }
+  }
+
+  if (failures.length > 0 && args.throwOnExternalApiError === true) {
+    throw new AggregateError(
+      failures,
+      `getMorphoUserRewards failed for chains: ${failedChainIds.join(", ")}`,
+    );
+  }
+
+  return fulfilled;
 }

--- a/src/actions/morpho/user-rewards/getMorphoUserRewards.ts
+++ b/src/actions/morpho/user-rewards/getMorphoUserRewards.ts
@@ -11,6 +11,13 @@ export type GetMorphoUserRewardsParameters<
   network extends Chain | undefined,
 > = OptionalNetworkParameterType<environments, network> & {
   userAddress: Address;
+  /**
+   * When true, errors from the external Merkl API are propagated to the
+   * caller instead of being swallowed and returning `[]`. Default `false`
+   * preserves the historical behavior for existing consumers; the frontend
+   * sets it `true` so React Query can surface a degradation notice.
+   */
+  throwOnExternalApiError?: boolean;
 };
 
 export type GetMorphoUserRewardsReturnType = Promise<MorphoUserReward[]>;
@@ -31,6 +38,9 @@ export async function getMorphoUserRewards<
         return getUserMorphoRewardsData({
           environment,
           account: args.userAddress,
+          ...(args.throwOnExternalApiError !== undefined && {
+            throwOnExternalApiError: args.throwOnExternalApiError,
+          }),
         });
       }),
   );

--- a/src/actions/morpho/user-rewards/getMorphoUserRewards.ts
+++ b/src/actions/morpho/user-rewards/getMorphoUserRewards.ts
@@ -4,7 +4,23 @@ import { getEnvironmentsFromArgs } from "../../../common/index.js";
 import type { OptionalNetworkParameterType } from "../../../common/types.js";
 import type { Chain } from "../../../environments/index.js";
 import type { MorphoUserReward } from "../../../types/morphoUserReward.js";
-import { getUserMorphoRewardsData } from "./common.js";
+import { MerklApiError, getUserMorphoRewardsData } from "./common.js";
+
+/**
+ * AggregateError thrown by `getMorphoUserRewards` when one or more chains
+ * fail and `throwOnExternalApiError` is `true`. The `rewards` property
+ * carries the rewards from any chains that succeeded so callers can still
+ * surface partial results alongside the per-chain failures in `errors`.
+ */
+export class MorphoUserRewardsAggregateError extends AggregateError {
+  readonly rewards: MorphoUserReward[];
+
+  constructor(errors: Error[], message: string, rewards: MorphoUserReward[]) {
+    super(errors, message);
+    this.name = "MorphoUserRewardsAggregateError";
+    this.rewards = rewards;
+  }
+}
 
 export type GetMorphoUserRewardsParameters<
   environments,
@@ -17,10 +33,10 @@ export type GetMorphoUserRewardsParameters<
    * preserves the historical behavior for existing consumers.
    *
    * If multiple environments are queried and at least one fails while others
-   * succeed, this throws an `AggregateError` whose `errors` array contains
-   * the per-chain failures. Successful chains' rewards are not returned in
-   * the error path; callers wanting partial success should set this to
-   * `false` (the default) and inspect logs for per-chain failures.
+   * succeed, this throws a `MorphoUserRewardsAggregateError` whose `errors`
+   * array contains the per-chain failures and whose `rewards` property
+   * carries the successful chains' rewards so the caller can still display
+   * partial results.
    */
   throwOnExternalApiError?: boolean;
 };
@@ -53,31 +69,34 @@ export async function getMorphoUserRewards<
   const fulfilled: MorphoUserReward[] = [];
   const failures: Error[] = [];
   const failedChainIds: number[] = [];
-  for (let i = 0; i < settled.length; i++) {
-    const result = settled[i];
+  for (const [i, result] of settled.entries()) {
     const environment = targetEnvironments[i];
-    if (result === undefined || environment === undefined) continue;
     if (result.status === "fulfilled") {
       fulfilled.push(...result.value);
-    } else {
-      const baseError =
-        result.reason instanceof Error
-          ? result.reason
-          : new Error(String(result.reason));
-      failures.push(
-        new Error(
-          `getMorphoUserRewards failed for chain ${environment.chainId}: ${baseError.message}`,
-          { cause: baseError },
-        ),
-      );
-      failedChainIds.push(environment.chainId);
+      continue;
     }
+    const reason = result.reason;
+    if (reason instanceof MerklApiError) {
+      failures.push(reason);
+      failedChainIds.push(reason.chainId);
+      continue;
+    }
+    const baseError =
+      reason instanceof Error ? reason : new Error(String(reason));
+    failures.push(
+      new Error(
+        `getMorphoUserRewards failed for chain ${environment.chainId}: ${baseError.message}`,
+        { cause: baseError },
+      ),
+    );
+    failedChainIds.push(environment.chainId);
   }
 
   if (failures.length > 0 && args.throwOnExternalApiError === true) {
-    throw new AggregateError(
+    throw new MorphoUserRewardsAggregateError(
       failures,
       `getMorphoUserRewards failed for chains: ${failedChainIds.join(", ")}`,
+      fulfilled,
     );
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,9 @@ export {
   type MoonwellClient,
 } from "./client/createMoonwellClient.js";
 
+export { MerklApiError } from "./actions/morpho/user-rewards/common.js";
+export { MorphoUserRewardsAggregateError } from "./actions/morpho/user-rewards/getMorphoUserRewards.js";
+
 export type {
   MarketConfig,
   MorphoMarketConfig,


### PR DESCRIPTION
## Summary

- Adds an optional `throwOnExternalApiError` parameter to `getMorphoUserRewards`. When `true`, Merkl API failures propagate to the caller instead of being silently swallowed and returning `[]`.
- Default remains `false` — every existing consumer sees no behavior change.
- Pairs with frontend graceful-degradation work: the rewards-page hook opts in so React Query can surface an inline "Morpho rewards unavailable" notice when Merkl is down, instead of indistinguishably showing "no Morpho rewards".

## Test plan

- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm lint` clean (Biome)
- [x] `pnpm test src/actions/morpho/user-rewards/common.test.ts` — 7/7 pass, including two new cases covering throw-on-error for non-ok responses and fetch rejections
- [x] `pnpm build` produces _cjs / _esm / _types successfully
- [ ] Companion frontend PR review (separate)