### PR TITLE
fix(morpho): polyfill AbortSignal.timeout for old Android WebViews

### DIFF
--- a/src/actions/morpho/utils/graphql.ts
+++ b/src/actions/morpho/utils/graphql.ts
@@ -1,4 +1,4 @@
-import { MOONWELL_FETCH_JSON_HEADERS } from "../../../common/fetch-headers.js";
+import { MOONWELL_FETCH_JSON_HEADERS, timeoutSignal } from "../../../common/fetch-headers.js";
 import type { Environment } from "../../../environments/index.js";
 import type { MorphoVaultV2ApyResponse } from "../../../types/morphoVault.js";
 
@@ -15,7 +15,7 @@ export async function getGraphQL<T>(
       method: "POST",
       headers: MOONWELL_FETCH_JSON_HEADERS,
       body: JSON.stringify({ query: query, operationName, variables }),
-      signal: AbortSignal.timeout(10000),
+      signal: timeoutSignal(10000),
     });
 
     const json = await response.json();
@@ -89,7 +89,7 @@ export async function getVaultV2Apy(
           chainId,
         },
       }),
-      signal: AbortSignal.timeout(10000),
+      signal: timeoutSignal(10000),
     });
 
     const json = await response.json();

--- a/src/actions/morpho/vaults/lunarIndexerTransform.ts
+++ b/src/actions/morpho/vaults/lunarIndexerTransform.ts
@@ -9,6 +9,7 @@
  */
 
 import { Amount } from "../../../common/amount.js";
+import { timeoutSignal } from "../../../common/fetch-headers.js";
 import type { Environment, TokenConfig } from "../../../environments/index.js";
 import type {
   MorphoVault,
@@ -331,7 +332,7 @@ export async function fetchTokenMap(
 ): Promise<Map<string, LunarIndexerToken>> {
   const url = `${lunarIndexerUrl}/api/v1/vaults/tokens/${chainId}`;
 
-  const response = await fetch(url, { signal: AbortSignal.timeout(10_000) });
+  const response = await fetch(url, { signal: timeoutSignal(10_000) });
 
   if (!response.ok) {
     throw new Error(
@@ -373,7 +374,7 @@ export async function fetchVaultsFromIndexer(
 
   const url = `${lunarIndexerUrl}/api/v1/vaults/vaults/${chainId}${params.toString() ? `?${params.toString()}` : ""}`;
 
-  const response = await fetch(url, { signal: AbortSignal.timeout(10_000) });
+  const response = await fetch(url, { signal: timeoutSignal(10_000) });
 
   if (!response.ok) {
     throw new Error(
@@ -397,7 +398,7 @@ export async function fetchVaultFromIndexer(
 ): Promise<LunarIndexerVault> {
   const url = `${lunarIndexerUrl}/api/v1/vaults/vault/${vaultId}`;
 
-  const response = await fetch(url, { signal: AbortSignal.timeout(10_000) });
+  const response = await fetch(url, { signal: timeoutSignal(10_000) });
 
   if (!response.ok) {
     throw new Error(
@@ -464,7 +465,7 @@ export async function fetchVaultSnapshotsFromIndexer(
   const queryString = params.toString();
   const url = `${lunarIndexerUrl}/api/v1/vaults/vault/${vaultId}/snapshots${queryString ? `?${queryString}` : ""}`;
 
-  const response = await fetch(url, { signal: AbortSignal.timeout(10_000) });
+  const response = await fetch(url, { signal: timeoutSignal(10_000) });
 
   if (!response.ok) {
     throw new Error(

--- a/src/common/fetch-headers.ts
+++ b/src/common/fetch-headers.ts
@@ -1,3 +1,19 @@
+/**
+ * AbortSignal.timeout() was added in Chrome 103 / Node 17.3 / Firefox 100.
+ * Older Android WebViews (Chrome < 103) don't have it, causing a TypeError at
+ * call-time that propagates to the caller as an unhandled SDK error.
+ * This helper returns a signal that times out after `ms` milliseconds regardless
+ * of runtime support.
+ */
+export function timeoutSignal(ms: number): AbortSignal {
+  if (typeof AbortSignal.timeout === "function") {
+    return AbortSignal.timeout(ms);
+  }
+  const controller = new AbortController();
+  setTimeout(() => controller.abort(), ms);
+  return controller.signal;
+}
+
 // Try to get the version from package.json, fallback to '1.0.0'
 let sdkVersion = "1.0.0";
 try {


### PR DESCRIPTION
## Summary

Fixes **MOONWELL-FRONTEND-RQ** — `TypeError: AbortSignal.timeout is not a function` crashing the homepage for users on older Android WebViews.

`AbortSignal.timeout()` is a static method introduced in Chrome 103 (Android 13 / mid-2022). Users on Android 12 or earlier (Chrome ≤ 102) hit a `TypeError` at startup when the SDK's Morpho vault and GraphQL fetch calls try to invoke it. The error surfaces as an unhandled SDK error on the `/` route.

**Root cause:** 6 direct `AbortSignal.timeout(ms)` callsites in `lunarIndexerTransform.ts` (×4) and `graphql.ts` (×2) with no runtime support check.

**Fix:** Adds `timeoutSignal(ms: number): AbortSignal` to `common/fetch-headers.ts`. It uses the native static method when present, otherwise falls back to an `AbortController` + `setTimeout` polyfill. All 6 callsites are updated.

## Affected files

- `src/common/fetch-headers.ts` — new `timeoutSignal` export
- `src/actions/morpho/vaults/lunarIndexerTransform.ts` — 4 callsites replaced
- `src/actions/morpho/utils/graphql.ts` — 2 callsites replaced

## Sentry reference

- **MOONWELL-FRONTEND-RQ** — first seen 2026-05-20, 4 events, affects Android 12 / Chrome 97 users

## Test plan

- [ ] `pnpm typecheck` clean
- [ ] `pnpm lint` clean
- [ ] Verify Morpho vaults load correctly on a Chrome 97 / Android 12 device or emulated UA
- [ ] Confirm `MOONWELL-FRONTEND-RQ` stops occurring after deploy

---
_Generated by [Claude Code](https://claude.ai/code/session_01F2XqnCJ1n1A8hzUFbWoyRh)_