### PR TITLE
fix(morpho): replace AbortSignal.timeout with cross-browser timeoutSignal helper

### DIFF
--- a/.changeset/fix-abortsignal-timeout-polyfill.md
+++ b/.changeset/fix-abortsignal-timeout-polyfill.md
@@ -1,0 +1,23 @@
+---
+"@moonwell-fi/moonwell-sdk": patch
+---
+
+fix(morpho): replace AbortSignal.timeout with cross-browser timeoutSignal helper
+
+`AbortSignal.timeout` was introduced in Chrome 103, Firefox 100, and Safari 15.4.
+Older browsers — notably Chrome Mobile 98 / Android 7.0 — that some Moonwell users
+still run do not support it. This surfaced as:
+
+  TypeError: AbortSignal.timeout is not a function
+
+when the Morpho vault fetch utilities (`getMorphoVaults`, `getGraphQL`) tried to
+set a request timeout, crashing the vaults page entirely on affected devices.
+
+Adds `src/common/abort-signal.ts` with `timeoutSignal(ms)` — a safe drop-in
+replacement that delegates to the native `AbortSignal.timeout` when available and
+falls back to `AbortController + setTimeout` on older environments.
+
+All six fetch sites in `graphql.ts` (2) and `lunarIndexerTransform.ts` (4) are
+updated to call `timeoutSignal` instead of `AbortSignal.timeout` directly.
+
+Fixes Sentry issue MOONWELL-FRONTEND-RQ.

--- a/src/actions/morpho/utils/graphql.ts
+++ b/src/actions/morpho/utils/graphql.ts
@@ -1,4 +1,5 @@
 import { MOONWELL_FETCH_JSON_HEADERS } from "../../../common/fetch-headers.js";
+import { timeoutSignal } from "../../../common/abort-signal.js";
 import type { Environment } from "../../../environments/index.js";
 import type { MorphoVaultV2ApyResponse } from "../../../types/morphoVault.js";
 
@@ -15,7 +16,7 @@ export async function getGraphQL<T>(
       method: "POST",
       headers: MOONWELL_FETCH_JSON_HEADERS,
       body: JSON.stringify({ query: query, operationName, variables }),
-      signal: AbortSignal.timeout(10000),
+      signal: timeoutSignal(10000),
     });
 
     const json = await response.json();
@@ -89,7 +90,7 @@ export async function getVaultV2Apy(
           chainId,
         },
       }),
-      signal: AbortSignal.timeout(10000),
+      signal: timeoutSignal(10000),
     });
 
     const json = await response.json();

--- a/src/actions/morpho/vaults/lunarIndexerTransform.ts
+++ b/src/actions/morpho/vaults/lunarIndexerTransform.ts
@@ -9,6 +9,7 @@
  */
 
 import { Amount } from "../../../common/amount.js";
+import { timeoutSignal } from "../../../common/abort-signal.js";
 import type { Environment, TokenConfig } from "../../../environments/index.js";
 import type {
   MorphoVault,
@@ -331,7 +332,7 @@ export async function fetchTokenMap(
 ): Promise<Map<string, LunarIndexerToken>> {
   const url = `${lunarIndexerUrl}/api/v1/vaults/tokens/${chainId}`;
 
-  const response = await fetch(url, { signal: AbortSignal.timeout(10_000) });
+  const response = await fetch(url, { signal: timeoutSignal(10_000) });
 
   if (!response.ok) {
     throw new Error(
@@ -373,7 +374,7 @@ export async function fetchVaultsFromIndexer(
 
   const url = `${lunarIndexerUrl}/api/v1/vaults/vaults/${chainId}${params.toString() ? `?${params.toString()}` : ""}`;
 
-  const response = await fetch(url, { signal: AbortSignal.timeout(10_000) });
+  const response = await fetch(url, { signal: timeoutSignal(10_000) });
 
   if (!response.ok) {
     throw new Error(
@@ -397,7 +398,7 @@ export async function fetchVaultFromIndexer(
 ): Promise<LunarIndexerVault> {
   const url = `${lunarIndexerUrl}/api/v1/vaults/vault/${vaultId}`;
 
-  const response = await fetch(url, { signal: AbortSignal.timeout(10_000) });
+  const response = await fetch(url, { signal: timeoutSignal(10_000) });
 
   if (!response.ok) {
     throw new Error(
@@ -464,7 +465,7 @@ export async function fetchVaultSnapshotsFromIndexer(
   const queryString = params.toString();
   const url = `${lunarIndexerUrl}/api/v1/vaults/vault/${vaultId}/snapshots${queryString ? `?${queryString}` : ""}`;
 
-  const response = await fetch(url, { signal: AbortSignal.timeout(10_000) });
+  const response = await fetch(url, { signal: timeoutSignal(10_000) });
 
   if (!response.ok) {
     throw new Error(

--- a/src/common/abort-signal.ts
+++ b/src/common/abort-signal.ts
@@ -1,0 +1,41 @@
+/**
+ * Cross-browser AbortSignal.timeout polyfill.
+ *
+ * `AbortSignal.timeout` was introduced in Chrome 103, Firefox 100, and Safari 15.4.
+ * Older browsers — notably Chrome Mobile 98 / Android 7.0 — that some Moonwell users
+ * still run do not support it, which surfaces as:
+ *
+ *   TypeError: AbortSignal.timeout is not a function
+ *
+ * when the Morpho vault fetch utilities try to set a request timeout.
+ *
+ * This module exposes `timeoutSignal(ms)` — a drop-in replacement that delegates
+ * to the native API when available and falls back to AbortController + setTimeout.
+ *
+ * Fixes Sentry issue MOONWELL-FRONTEND-RQ.
+ */
+
+/**
+ * Returns an AbortSignal that fires after `ms` milliseconds.
+ *
+ * Uses the native `AbortSignal.timeout` where available (Chrome 103+, Firefox 100+,
+ * Safari 15.4+) and falls back to `AbortController + setTimeout` for older browsers.
+ */
+export function timeoutSignal(ms: number): AbortSignal {
+  if (
+    typeof AbortSignal !== "undefined" &&
+    typeof AbortSignal.timeout === "function"
+  ) {
+    return AbortSignal.timeout(ms);
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(
+    () => controller.abort(new DOMException("TimeoutError", "TimeoutError")),
+    ms,
+  );
+  // Avoid a dangling timer if the request resolves before the timeout fires.
+  controller.signal.addEventListener("abort", () => clearTimeout(timer), {
+    once: true,
+  });
+  return controller.signal;
+}


### PR DESCRIPTION
## Problem

`AbortSignal.timeout` was introduced in Chrome 103 / Firefox 100 / Safari 15.4. Users on older devices — notably **Chrome Mobile 98 / Android 7.0** — that still visit Moonwell hit:

```
TypeError: AbortSignal.timeout is not a function
```

when the SDK's Morpho vault fetch utilities (`getMorphoVaults` → `graphql.ts`, `lunarIndexerTransform.ts`) try to set a 10-second request timeout. This crashes the vaults page entirely on affected devices.

**Sentry impact (last 24 h):**

| Issue | Events | Users | Status |
|---|---|---|---|
| MOONWELL-FRONTEND-RQ | 38 | 0 (untracked) | 🟡 new, recurring daily |

First seen: 2026-05-20. The error hits the home page (`/`) on every load for users on old Android WebView or Chrome Mobile <103.

## Fix

Adds `src/common/abort-signal.ts` with `timeoutSignal(ms)` — a drop-in replacement that:
- Delegates to the native `AbortSignal.timeout` when available (modern browsers, Node 17.3+)
- Falls back to `AbortController + setTimeout` on older environments

Updates all **6** call sites:
- `src/actions/morpho/utils/graphql.ts` (2 occurrences)
- `src/actions/morpho/vaults/lunarIndexerTransform.ts` (4 occurrences)

## Files Changed

- `src/common/abort-signal.ts` — new `timeoutSignal` utility
- `src/actions/morpho/utils/graphql.ts` — swap `AbortSignal.timeout` → `timeoutSignal`
- `src/actions/morpho/vaults/lunarIndexerTransform.ts` — swap all 4 occurrences
- `.changeset/fix-abortsignal-timeout-polyfill.md` — patch changeset

## Test Plan

- [ ] `pnpm typecheck` clean
- [ ] `pnpm lint` clean
- [ ] `pnpm test` — existing tests pass; `timeoutSignal` degrades gracefully when `AbortSignal.timeout` is stubbed out
- [ ] Verify Sentry MOONWELL-FRONTEND-RQ stops firing after SDK bump in frontend

## Companion PR

A frontend-side polyfill (belt-and-suspenders) is in [moonwell-frontend-v2-react](https://github.com/moonwell-fi/moonwell-frontend-v2-react/pulls) on branch `claude/hopeful-bardeen-1RM6v`.

https://claude.ai/code/session_01Hs2JnDzBhzvqZFoXuTMC15

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hs2JnDzBhzvqZFoXuTMC15)_