### PR TITLE
Add mainnet support for multigovernor

### DIFF
--- a/.changeset/eth-full-views.md
+++ b/.changeset/eth-full-views.md
@@ -1,0 +1,5 @@
+---
+"@moonwell-fi/moonwell-sdk": minor
+---
+
+Wire the full Ethereum CoreViews contract (`0xA061Ed814bBd1b03e8df0B7AbEbc40f4A6feb895`), replacing the staking-only proxy, and expose the Ethereum MultichainGovernor (`0x8769B70ac7c93AF0e75de0D69877709B66d75838`) so consumers can cast votes on Eth-side proposals. `getUserVotingPowers` and `getDelegates` now include Ethereum mainnet alongside Moonbeam, Base, and Optimism.

--- a/.changeset/eth-ipfs-descriptions.md
+++ b/.changeset/eth-ipfs-descriptions.md
@@ -1,0 +1,5 @@
+---
+"@moonwell-fi/moonwell-sdk": minor
+---
+
+Resolve Eth multigov proposal descriptions from IPFS via Pinata. The lunar indexer now surfaces these as `ipfs://<hash>` URIs; the SDK fetches and substitutes the plaintext markdown before subtitle extraction so consumers see resolved descriptions. On per-proposal IPFS fetch failure the `ipfs://` URI is left in place — frontend consumers can detect this with `description.startsWith("ipfs://")` if they want to show a fallback.

--- a/.changeset/eth-ipfs-descriptions.md
+++ b/.changeset/eth-ipfs-descriptions.md
@@ -2,4 +2,4 @@
 "@moonwell-fi/moonwell-sdk": minor
 ---
 
-Resolve Eth multigov proposal descriptions from IPFS via Pinata. The lunar indexer now surfaces these as `ipfs://<hash>` URIs; the SDK fetches and substitutes the plaintext markdown before subtitle extraction so consumers see resolved descriptions. On per-proposal IPFS fetch failure the `ipfs://` URI is left in place — frontend consumers can detect this with `description.startsWith("ipfs://")` if they want to show a fallback.
+Resolve Eth multigov proposal descriptions from IPFS via Pinata. The lunar indexer now surfaces these as `ipfs://<hash>` URIs; the SDK fetches and substitutes the plaintext markdown before subtitle extraction so consumers see resolved descriptions. Per-proposal fetch failures are routed through `env.onError` (matching `getProposalData` / `getExtendedProposalData`) and the `ipfs://` URI is left in place — frontend consumers can detect this with `description.startsWith("ipfs://")` if they want to show a fallback. Non-string gateway responses are rejected explicitly so they don't poison the in-memory cache.

--- a/src/actions/governance/getDelegates.test.ts
+++ b/src/actions/governance/getDelegates.test.ts
@@ -6,5 +6,11 @@ describe("Testing delegates", () => {
     const delegates = await testClient.getDelegates();
     expect(delegates).toBeDefined();
     expect(delegates.length).toBeGreaterThan(0);
+    // Regression guard for PR #284: with the full Eth views wired and
+    // `mainnet.id` added to `targetChainIds`, at least one delegate must
+    // carry a voting-power entry keyed by chainId 1.
+    expect(
+      delegates.some((d) => d.votingPower !== undefined && 1 in d.votingPower),
+    ).toBe(true);
   });
 });

--- a/src/actions/governance/getDelegates.ts
+++ b/src/actions/governance/getDelegates.ts
@@ -1,5 +1,5 @@
 import { isAddress } from "viem";
-import { base, moonbeam, optimism } from "viem/chains";
+import { base, mainnet, moonbeam, optimism } from "viem/chains";
 import type { MoonwellClient } from "../../client/createMoonwellClient.js";
 import {
   type Environment,
@@ -28,10 +28,12 @@ export async function getDelegates(
   const apiVoters = await fetchAllVoters(governanceEnvironment);
   const forumProfiles = await getForumProfiles();
 
-  // Mainnet stays excluded: the Eth views contract is staking-only and does
-  // not expose getUserVotingPower. Add mainnet.id here when a full Eth views
-  // contract ships, to match WELL.chainIds in environments/definitions/governance.ts.
-  const targetChainIds = [moonbeam.id, base.id, optimism.id] as const;
+  const targetChainIds = [
+    moonbeam.id,
+    base.id,
+    optimism.id,
+    mainnet.id,
+  ] as const;
   const envs = Object.values(client.environments as Environment[]).filter(
     (env) =>
       env.contracts.views !== undefined &&

--- a/src/actions/governance/getUserVotingPowers.test.ts
+++ b/src/actions/governance/getUserVotingPowers.test.ts
@@ -1,5 +1,4 @@
 import type { Address } from "viem";
-import { mainnet } from "viem/chains";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { testClient } from "../../../test/client.js";
 import type { MoonwellClient } from "../../client/createMoonwellClient.js";
@@ -25,8 +24,7 @@ const mockedHelper = vi.mocked(getBlockNumberAtTimestamp);
 
 describe("Testing user voting powers", () => {
   // Only iterate environments where the queried governance token is configured
-  // AND a full governance views contract is deployed (must expose
-  // getUserVotingPower, not just the staking-only subset on Ethereum). Calling
+  // and a views contract is deployed. Calling
   // getUserVotingPowers({governanceToken: "WELL"}) on a chain that holds WELL
   // but is not the governance hub correctly returns [], which would fail the
   // `length > 0` assertion.
@@ -37,9 +35,7 @@ describe("Testing user voting powers", () => {
         | undefined;
       const contracts = environment.contracts as { views?: unknown };
       return (
-        custom?.governance?.token === "WELL" &&
-        contracts.views !== undefined &&
-        environment.chainId !== mainnet.id
+        custom?.governance?.token === "WELL" && contracts.views !== undefined
       );
     })
     .forEach(([networkKey, environment]) => {

--- a/src/actions/governance/getUserVotingPowers.test.ts
+++ b/src/actions/governance/getUserVotingPowers.test.ts
@@ -24,10 +24,9 @@ const mockedHelper = vi.mocked(getBlockNumberAtTimestamp);
 
 describe("Testing user voting powers", () => {
   // Only iterate environments where the queried governance token is configured
-  // and a views contract is deployed. Calling
-  // getUserVotingPowers({governanceToken: "WELL"}) on a chain that holds WELL
-  // but is not the governance hub correctly returns [], which would fail the
-  // `length > 0` assertion.
+  // and a views contract is deployed — those are the chains
+  // `getUserVotingPowers` actually reads from. Chains that hold the token but
+  // have no views wired return [], which would trip the `length > 0` assertion.
   Object.entries(testClient.environments)
     .filter(([, environment]) => {
       const custom = environment.custom as
@@ -182,6 +181,47 @@ describe("getUserVotingPowers — snapshotTimestamp", () => {
     expect(mockedHelper).not.toHaveBeenCalled();
     expect(reads.chainA).toHaveBeenCalledWith([USER], { blockNumber: 42n });
     expect(reads.chainB).toHaveBeenCalledWith([USER], { blockNumber: 42n });
+  });
+
+  test("mainnet (chainId=1) is included once a views contract is wired (regression guard for PR #284)", async () => {
+    const mainnetRead = vi.fn(async () => ZERO_USER_VOTES);
+    const baseRead = vi.fn(async () => ZERO_USER_VOTES);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const client = {
+      environments: {
+        mainnet: {
+          chainId: 1,
+          custom: { governance: { token: "WELL" } },
+          contracts: {
+            views: { read: { getUserVotingPower: mainnetRead } },
+          },
+        },
+        base: {
+          chainId: 8453,
+          custom: { governance: { token: "WELL" } },
+          contracts: {
+            views: { read: { getUserVotingPower: baseRead } },
+          },
+        },
+      },
+    } as unknown as MoonwellClient;
+
+    const result = await getUserVotingPowers(client, {
+      governanceToken: "WELL",
+      userAddress: USER,
+    });
+
+    expect(result.map((r) => r.chainId).sort()).toEqual([1, 8453]);
+    expect(mainnetRead).toHaveBeenCalledTimes(1);
+    // The "staking-only" warning from the removed STAKING_ONLY_VIEWS_CHAIN_IDS
+    // skip must not fire for mainnet anymore.
+    const stakingOnlyWarnings = warnSpy.mock.calls.filter((call) =>
+      String(call[0]).includes("staking-only"),
+    );
+    expect(stakingOnlyWarnings).toHaveLength(0);
+
+    warnSpy.mockRestore();
   });
 
   test("environments without a views contract are excluded from results", async () => {

--- a/src/actions/governance/getUserVotingPowers.ts
+++ b/src/actions/governance/getUserVotingPowers.ts
@@ -1,5 +1,4 @@
 import { type Address, zeroAddress } from "viem";
-import { mainnet } from "viem/chains";
 import type { MoonwellClient } from "../../client/createMoonwellClient.js";
 import {
   Amount,
@@ -11,11 +10,6 @@ import type { Chain, GovernanceToken } from "../../environments/index.js";
 import type { UserVotingPowers } from "../../types/userVotingPowers.js";
 
 const warnedSkippedEnvs = new Set<string>();
-
-// Ethereum's views contract is staking-only (exposes getUserStakingVotingPower
-// but not the cross-source getUserVotingPower used here). Reading it on Eth
-// would revert at runtime, so we skip those chains explicitly.
-const STAKING_ONLY_VIEWS_CHAIN_IDS: ReadonlySet<number> = new Set([mainnet.id]);
 
 export type GetUserVotingPowersParameters<
   environments,
@@ -71,16 +65,6 @@ export async function getUserVotingPowers<
         warnedSkippedEnvs.add(key);
         console.warn(
           `[moonwell-sdk] getUserVotingPowers: skipping chainId=${env.chainId} for governanceToken=${governanceToken} — environment holds the token but has no views contract.`,
-        );
-      }
-      return [];
-    }
-    if (STAKING_ONLY_VIEWS_CHAIN_IDS.has(env.chainId)) {
-      const key = `${env.chainId}:${governanceToken}:staking-only`;
-      if (!warnedSkippedEnvs.has(key)) {
-        warnedSkippedEnvs.add(key);
-        console.warn(
-          `[moonwell-sdk] getUserVotingPowers: skipping chainId=${env.chainId} for governanceToken=${governanceToken} — views contract is staking-only and does not expose getUserVotingPower.`,
         );
       }
       return [];

--- a/src/actions/governance/ipfs.test.ts
+++ b/src/actions/governance/ipfs.test.ts
@@ -1,5 +1,11 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { Environment } from "../../environments/index.js";
 import type { ApiProposal } from "./governor-api-client.js";
+
+const ENV_NOOP = {
+  chainId: 1284,
+  onError: vi.fn(),
+} as unknown as Environment;
 
 // Mock axios so the gateway URL is asserted directly and no real HTTP fires.
 vi.mock("axios", () => {
@@ -97,7 +103,7 @@ describe("resolveIpfsDescriptions", () => {
     const proposals = [ipfsProposal, plainProposal];
 
     const { resolveIpfsDescriptions } = await importIpfsModule();
-    await resolveIpfsDescriptions(proposals);
+    await resolveIpfsDescriptions(proposals, ENV_NOOP);
 
     expect(ipfsProposal.description).toBe("# Resolved markdown");
     expect(plainProposal.description).toBe("# Already inlined");
@@ -107,14 +113,53 @@ describe("resolveIpfsDescriptions", () => {
   test("leaves the ipfs:// URI in place when the fetch fails and does not reject", async () => {
     mockedAxiosGet.mockRejectedValueOnce(new Error("gateway down"));
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const onError = vi.fn();
+    const env = { chainId: 1284, onError } as unknown as Environment;
 
     const proposal = buildProposal(`ipfs://${HASH}`);
 
     const { resolveIpfsDescriptions } = await importIpfsModule();
-    await expect(resolveIpfsDescriptions([proposal])).resolves.toBeUndefined();
+    await expect(
+      resolveIpfsDescriptions([proposal], env),
+    ).resolves.toBeUndefined();
     expect(proposal.description).toBe(`ipfs://${HASH}`);
     expect(warnSpy).toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledWith(expect.any(Error), {
+      source: "governance-ipfs-description",
+      chainId: proposal.chainId,
+    });
 
     warnSpy.mockRestore();
   });
+
+  test.each([
+    ["object", { foo: "bar" }],
+    ["null", null],
+    ["undefined", undefined],
+  ])(
+    "non-string response body (%s) does not poison the cache — URI is preserved",
+    async (_label, badBody) => {
+      mockedAxiosGet.mockResolvedValueOnce({ data: badBody });
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const onError = vi.fn();
+      const env = { chainId: 1284, onError } as unknown as Environment;
+
+      const proposal = buildProposal(`ipfs://${HASH}`);
+      const ipfs = await importIpfsModule();
+      await ipfs.resolveIpfsDescriptions([proposal], env);
+
+      expect(proposal.description).toBe(`ipfs://${HASH}`);
+      expect(onError).toHaveBeenCalled();
+
+      // A second resolve must not return the bad body from cache —
+      // it should retry. Stub a good response and verify the URI is
+      // replaced this time.
+      mockedAxiosGet.mockResolvedValueOnce({ data: "# Good now" });
+      const retry = buildProposal(`ipfs://${HASH}`);
+      await ipfs.resolveIpfsDescriptions([retry], env);
+      expect(retry.description).toBe("# Good now");
+
+      warnSpy.mockRestore();
+    },
+  );
 });

--- a/src/actions/governance/ipfs.test.ts
+++ b/src/actions/governance/ipfs.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { ApiProposal } from "./governor-api-client.js";
+
+// Mock axios so the gateway URL is asserted directly and no real HTTP fires.
+vi.mock("axios", () => {
+  const get = vi.fn();
+  return { default: { get, isAxiosError: () => false } };
+});
+
+const axiosModule = await import("axios");
+const mockedAxiosGet = vi.mocked(axiosModule.default.get);
+
+// Import *after* the mock so the module-level cache is exercised against the
+// mocked axios. Each test calls resetIpfsCacheForTesting via re-importing.
+const importIpfsModule = async () => {
+  vi.resetModules();
+  return await import("./ipfs.js");
+};
+
+const HASH = "bafkreifs7zrxhb4rrxj6fwtiddymiejdtuu2ej2etcdvqnnrw5nyjbui4m";
+const GATEWAY_URL = `https://d4529a05.mypinata.cloud/ipfs/${HASH}`;
+
+describe("parseIpfsHash", () => {
+  test("returns the hash for a valid ipfs:// URI", async () => {
+    const { parseIpfsHash } = await importIpfsModule();
+    expect(parseIpfsHash(`ipfs://${HASH}`)).toBe(HASH);
+  });
+
+  test("returns null for non-IPFS inputs", async () => {
+    const { parseIpfsHash } = await importIpfsModule();
+    expect(parseIpfsHash(undefined)).toBeNull();
+    expect(parseIpfsHash("")).toBeNull();
+    expect(parseIpfsHash("https://example.com/foo")).toBeNull();
+    expect(parseIpfsHash("ipfs:/missing-second-slash")).toBeNull();
+    expect(parseIpfsHash("ipfs://")).toBeNull(); // empty hash
+  });
+});
+
+describe("fetchIpfsContent", () => {
+  beforeEach(() => {
+    mockedAxiosGet.mockReset();
+  });
+
+  test("hits the Pinata gateway with the parsed hash and returns the body", async () => {
+    mockedAxiosGet.mockResolvedValueOnce({ data: "# Hello world" });
+
+    const { fetchIpfsContent } = await importIpfsModule();
+    const body = await fetchIpfsContent(HASH);
+
+    expect(body).toBe("# Hello world");
+    expect(mockedAxiosGet).toHaveBeenCalledTimes(1);
+    expect(mockedAxiosGet).toHaveBeenCalledWith(
+      GATEWAY_URL,
+      expect.objectContaining({ responseType: "text" }),
+    );
+  });
+
+  test("caches by hash — second call with the same hash skips the network", async () => {
+    mockedAxiosGet.mockResolvedValueOnce({ data: "# Hello world" });
+
+    const { fetchIpfsContent } = await importIpfsModule();
+    const first = await fetchIpfsContent(HASH);
+    const second = await fetchIpfsContent(HASH);
+
+    expect(first).toBe("# Hello world");
+    expect(second).toBe("# Hello world");
+    expect(mockedAxiosGet).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("resolveIpfsDescriptions", () => {
+  beforeEach(() => {
+    mockedAxiosGet.mockReset();
+  });
+
+  const buildProposal = (description: string): ApiProposal =>
+    ({
+      proposalId: 1,
+      chainId: 1,
+      proposer: "0x0",
+      description,
+      targets: [],
+      calldatas: [],
+      forVotes: "0",
+      againstVotes: "0",
+      abstainVotes: "0",
+      votingStartTime: 0,
+      votingEndTime: 0,
+      blockNumber: 0,
+    }) as unknown as ApiProposal;
+
+  test("replaces ipfs:// descriptions in place and leaves plain markdown untouched", async () => {
+    mockedAxiosGet.mockResolvedValueOnce({ data: "# Resolved markdown" });
+
+    const ipfsProposal = buildProposal(`ipfs://${HASH}`);
+    const plainProposal = buildProposal("# Already inlined");
+    const proposals = [ipfsProposal, plainProposal];
+
+    const { resolveIpfsDescriptions } = await importIpfsModule();
+    await resolveIpfsDescriptions(proposals);
+
+    expect(ipfsProposal.description).toBe("# Resolved markdown");
+    expect(plainProposal.description).toBe("# Already inlined");
+    expect(mockedAxiosGet).toHaveBeenCalledTimes(1);
+  });
+
+  test("leaves the ipfs:// URI in place when the fetch fails and does not reject", async () => {
+    mockedAxiosGet.mockRejectedValueOnce(new Error("gateway down"));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const proposal = buildProposal(`ipfs://${HASH}`);
+
+    const { resolveIpfsDescriptions } = await importIpfsModule();
+    await expect(resolveIpfsDescriptions([proposal])).resolves.toBeUndefined();
+    expect(proposal.description).toBe(`ipfs://${HASH}`);
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+});

--- a/src/actions/governance/ipfs.ts
+++ b/src/actions/governance/ipfs.ts
@@ -1,3 +1,4 @@
+import type { Environment } from "../../environments/index.js";
 import { getWithRetry } from "../axiosWithRetry.js";
 import type { ApiProposal } from "./governor-api-client.js";
 
@@ -15,16 +16,17 @@ const ipfsContentCache = new Map<string, string>();
  */
 export const parseIpfsHash = (uri: string | undefined): string | null => {
   if (!uri) return null;
-  const match = uri.match(/^ipfs:\/\/(.+)$/);
-  return match ? match[1]! : null;
+  return uri.match(/^ipfs:\/\/(.+)$/)?.[1] ?? null;
 };
 
 /**
  * Fetch a single IPFS resource via the Pinata gateway. Cached by hash.
  *
- * `responseType: "text"` keeps axios from JSON-parsing the markdown body
- * (the body usually starts with `#` which isn't valid JSON anyway, but
- * being explicit avoids edge cases on content-type mismatch).
+ * `responseType: "text"` disables axios's default JSON auto-parse so we keep
+ * the markdown body verbatim. We additionally reject non-string responses so
+ * an HTML error page or JSON payload doesn't poison the cache as
+ * `"[object Object]"` — the caller's per-proposal catch keeps the `ipfs://`
+ * URI in place when that happens.
  */
 export const fetchIpfsContent = async (hash: string): Promise<string> => {
   const cached = ipfsContentCache.get(hash);
@@ -33,9 +35,13 @@ export const fetchIpfsContent = async (hash: string): Promise<string> => {
   const response = await getWithRetry<string>(`${PINATA_GATEWAY}/${hash}`, {
     responseType: "text",
   });
-  const body = String(response.data ?? "");
-  ipfsContentCache.set(hash, body);
-  return body;
+  if (typeof response.data !== "string") {
+    throw new Error(
+      `[fetchIpfsContent] non-string body for hash=${hash} (typeof=${typeof response.data})`,
+    );
+  }
+  ipfsContentCache.set(hash, response.data);
+  return response.data;
 };
 
 /**
@@ -43,13 +49,17 @@ export const fetchIpfsContent = async (hash: string): Promise<string> => {
  * underlying markdown from Pinata and replace `description` in place. All
  * fetches run in parallel.
  *
- * Failures are logged and swallowed per-proposal: the `ipfs://` URI is left
- * untouched so consumers can detect (e.g. via `description.startsWith("ipfs://")`)
- * and render a fallback. The bulk call never rejects, so a single bad pin
- * doesn't kill `getProposals()` for everyone.
+ * Failures are logged via console.warn AND surfaced through
+ * `env.onError` (matching the convention used by `getProposalData` /
+ * `getExtendedProposalData`), then swallowed per-proposal: the `ipfs://` URI
+ * is left untouched so consumers can detect (e.g. via
+ * `description.startsWith("ipfs://")`) and render a fallback. The bulk call
+ * never rejects, so a single bad pin doesn't kill `getProposals()` for
+ * everyone.
  */
 export const resolveIpfsDescriptions = async (
   proposals: ApiProposal[],
+  env: Environment,
 ): Promise<void> => {
   await Promise.all(
     proposals.map(async (proposal) => {
@@ -62,6 +72,10 @@ export const resolveIpfsDescriptions = async (
           `[resolveIpfsDescriptions] failed to fetch hash=${hash}:`,
           error,
         );
+        env.onError?.(error, {
+          source: "governance-ipfs-description",
+          chainId: proposal.chainId,
+        });
       }
     }),
   );

--- a/src/actions/governance/ipfs.ts
+++ b/src/actions/governance/ipfs.ts
@@ -1,0 +1,68 @@
+import { getWithRetry } from "../axiosWithRetry.js";
+import type { ApiProposal } from "./governor-api-client.js";
+
+const PINATA_GATEWAY = "https://d4529a05.mypinata.cloud/ipfs";
+
+// IPFS content is content-addressed, so a per-hash result is immutable and the
+// cache lives for the process lifetime — no TTL needed. Repeated getProposals()
+// calls in the same Node/browser session reuse the resolved markdown.
+const ipfsContentCache = new Map<string, string>();
+
+/**
+ * Strip the `ipfs://` prefix from an indexer-supplied URI. Returns null for
+ * anything that isn't an IPFS URI (including empty strings and undefined),
+ * which lets callers skip the fetch with a single check.
+ */
+export const parseIpfsHash = (uri: string | undefined): string | null => {
+  if (!uri) return null;
+  const match = uri.match(/^ipfs:\/\/(.+)$/);
+  return match ? match[1]! : null;
+};
+
+/**
+ * Fetch a single IPFS resource via the Pinata gateway. Cached by hash.
+ *
+ * `responseType: "text"` keeps axios from JSON-parsing the markdown body
+ * (the body usually starts with `#` which isn't valid JSON anyway, but
+ * being explicit avoids edge cases on content-type mismatch).
+ */
+export const fetchIpfsContent = async (hash: string): Promise<string> => {
+  const cached = ipfsContentCache.get(hash);
+  if (cached !== undefined) return cached;
+
+  const response = await getWithRetry<string>(`${PINATA_GATEWAY}/${hash}`, {
+    responseType: "text",
+  });
+  const body = String(response.data ?? "");
+  ipfsContentCache.set(hash, body);
+  return body;
+};
+
+/**
+ * For every proposal whose `description` is an `ipfs://` URI, fetch the
+ * underlying markdown from Pinata and replace `description` in place. All
+ * fetches run in parallel.
+ *
+ * Failures are logged and swallowed per-proposal: the `ipfs://` URI is left
+ * untouched so consumers can detect (e.g. via `description.startsWith("ipfs://")`)
+ * and render a fallback. The bulk call never rejects, so a single bad pin
+ * doesn't kill `getProposals()` for everyone.
+ */
+export const resolveIpfsDescriptions = async (
+  proposals: ApiProposal[],
+): Promise<void> => {
+  await Promise.all(
+    proposals.map(async (proposal) => {
+      const hash = parseIpfsHash(proposal.description);
+      if (!hash) return;
+      try {
+        proposal.description = await fetchIpfsContent(hash);
+      } catch (error) {
+        console.warn(
+          `[resolveIpfsDescriptions] failed to fetch hash=${hash}:`,
+          error,
+        );
+      }
+    }),
+  );
+};

--- a/src/actions/governance/proposals/common.test.ts
+++ b/src/actions/governance/proposals/common.test.ts
@@ -236,4 +236,31 @@ describe("getProposalsOnChainData cross-chain skip", () => {
     const [onChainData] = await getProposalsOnChainData([proposal], env);
     expect(onChainData?.state).toBe(ProposalState.Active);
   });
+
+  test("uses options.crossChainQuorums when supplied; falls back to 0n otherwise", async () => {
+    const env = {
+      chainId: 1284,
+      contracts: {},
+      custom: {},
+    } as unknown as Parameters<typeof getProposalsOnChainData>[1];
+    const ethProposal: ApiProposal = {
+      ...baseApiProposal,
+      chainId: 1,
+      proposalId: 42,
+      stateChanges: [],
+    };
+
+    const [withMap] = await getProposalsOnChainData([ethProposal], env, {
+      crossChainQuorums: new Map([[1, 9_876n]]),
+    });
+    expect(withMap?.quorum).toBe(9_876n);
+
+    const [withoutMap] = await getProposalsOnChainData([ethProposal], env);
+    expect(withoutMap?.quorum).toBe(0n);
+
+    const [missingEntry] = await getProposalsOnChainData([ethProposal], env, {
+      crossChainQuorums: new Map([[42, 1n]]), // wrong chainId
+    });
+    expect(missingEntry?.quorum).toBe(0n);
+  });
 });

--- a/src/actions/governance/proposals/common.ts
+++ b/src/actions/governance/proposals/common.ts
@@ -263,11 +263,55 @@ const getLegacyArtemisMaxId = async (
 };
 
 /**
+ * Reads the multichain governor's quorum on every chain that holds an active
+ * proposal but isn't the one we'd normally read through. Returns a chainId →
+ * quorum map; chains with no `multichainGovernor` wired are omitted (callers
+ * fall back to 0n).
+ *
+ * Lives at the caller level (vs. inside `getProposalsOnChainData`) so the
+ * `publicEnvironments` dependency stays explicit — tests that hand
+ * `getProposalsOnChainData` a fake env don't accidentally trigger real RPC
+ * reads against production contracts.
+ */
+export const readCrossChainQuorums = async (
+  apiProposals: ApiProposal[],
+  governanceEnvironment: Environment,
+): Promise<Map<number, bigint>> => {
+  const otherChainIds = Array.from(
+    new Set(
+      apiProposals
+        .map((p) => p.chainId)
+        .filter((c) => c !== governanceEnvironment.chainId),
+    ),
+  );
+  const quorums = new Map<number, bigint>();
+  await Promise.all(
+    otherChainIds.map(async (chainId) => {
+      const env = (Object.values(publicEnvironments) as Environment[]).find(
+        (e) => e.chainId === chainId,
+      );
+      const mg = env?.contracts.multichainGovernor;
+      if (!mg) return;
+      try {
+        quorums.set(chainId, await mg.read.quorum());
+      } catch (error) {
+        console.warn(
+          `[readCrossChainQuorums] quorum read failed for chainId=${chainId}:`,
+          error,
+        );
+      }
+    }),
+  );
+  return quorums;
+};
+
+/**
  * Fetches on-chain data for multiple proposals
  */
 export const getProposalsOnChainData = async (
   apiProposals: ApiProposal[],
   governanceEnvironment: Environment,
+  options?: { crossChainQuorums?: Map<number, bigint> },
 ): Promise<ProposalOnChainData[]> => {
   let quorum = 0n;
 
@@ -289,9 +333,12 @@ export const getProposalsOnChainData = async (
   const onChainDataList = await Promise.all(
     apiProposals.map(async (p) => {
       // Proposals from a different chain than the governance env (e.g. chainId=1
-      // Ethereum proposals fetched through the Moonbeam env) can't be read from
-      // this env's contracts — derive state from API events here so callers
-      // never see a misleading `state: 0` default for finalized proposals.
+      // Ethereum proposals fetched through the Moonbeam env) can't have their
+      // state read from this env's contracts — derive state from API events here
+      // so callers never see a misleading `state: 0` default for finalized
+      // proposals. Quorum, however, comes from a per-chain map populated by the
+      // caller via `readCrossChainQuorums` (defaulting to 0n when the caller
+      // didn't pre-fetch, e.g. in unit tests).
       if (p.chainId !== governanceEnvironment.chainId) {
         const formatted = formatApiProposalData(p);
         return {
@@ -299,7 +346,7 @@ export const getProposalsOnChainData = async (
           proposalData: null,
           eta: 0,
           votesCollected: false,
-          quorum: 0n,
+          quorum: options?.crossChainQuorums?.get(p.chainId) ?? 0n,
         };
       }
 

--- a/src/actions/governance/proposals/common.ts
+++ b/src/actions/governance/proposals/common.ts
@@ -265,13 +265,14 @@ const getLegacyArtemisMaxId = async (
 /**
  * Reads the multichain governor's quorum on every chain that holds an active
  * proposal but isn't the one we'd normally read through. Returns a chainId →
- * quorum map; chains with no `multichainGovernor` wired are omitted (callers
- * fall back to 0n).
+ * quorum map; chains with no `multichainGovernor` wired are omitted, as are
+ * chains whose quorum read reverted. Callers substitute `0n` for misses via
+ * the `options.crossChainQuorums?.get(...) ?? 0n` pattern.
  *
- * Lives at the caller level (vs. inside `getProposalsOnChainData`) so the
- * `publicEnvironments` dependency stays explicit — tests that hand
- * `getProposalsOnChainData` a fake env don't accidentally trigger real RPC
- * reads against production contracts.
+ * Read failures are routed through `onError` so Sentry-wired consumers see
+ * them — matching `getProposalData` / `getCrossChainProposalData` /
+ * `getExtendedProposalData`. The caller's `governanceEnvironment` carries
+ * `onError` since we don't have one per foreign chain in scope.
  */
 export const readCrossChainQuorums = async (
   apiProposals: ApiProposal[],
@@ -299,6 +300,10 @@ export const readCrossChainQuorums = async (
           `[readCrossChainQuorums] quorum read failed for chainId=${chainId}:`,
           error,
         );
+        governanceEnvironment.onError?.(error, {
+          source: "governance-cross-chain-quorum",
+          chainId,
+        });
       }
     }),
   );

--- a/src/actions/governance/proposals/getProposal.test.ts
+++ b/src/actions/governance/proposals/getProposal.test.ts
@@ -114,6 +114,14 @@ describe("getProposal state post-processing", () => {
     } as unknown as Parameters<typeof getProposal>[1]);
 
     expect(result?.state).toBe(1); // ProposalState.Active
+    // Regression guard against #3: the third argument carrying
+    // `crossChainQuorums` must reach getProposalsOnChainData. A wiring
+    // regression that drops it would still make assertions on `state` pass.
+    expect(mockedOnChain).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.anything(),
+      expect.objectContaining({ crossChainQuorums: expect.any(Map) }),
+    );
   });
 
   test("EXECUTED state-change forces state=Executed regardless of on-chain state", async () => {

--- a/src/actions/governance/proposals/getProposal.ts
+++ b/src/actions/governance/proposals/getProposal.ts
@@ -10,6 +10,7 @@ import {
   fetchProposal,
   isNotFoundError,
 } from "../governor-api-client.js";
+import { resolveIpfsDescriptions } from "../ipfs.js";
 import {
   appendProposalExtendedData,
   formatApiProposalData,
@@ -91,6 +92,8 @@ async function getMoonbeamProposal(
   if (!apiProposal) {
     return undefined;
   }
+
+  await resolveIpfsDescriptions([apiProposal]);
 
   const formattedData = formatApiProposalData(apiProposal);
   const crossChainQuorums = await readCrossChainQuorums(

--- a/src/actions/governance/proposals/getProposal.ts
+++ b/src/actions/governance/proposals/getProposal.ts
@@ -93,13 +93,12 @@ async function getMoonbeamProposal(
     return undefined;
   }
 
-  await resolveIpfsDescriptions([apiProposal]);
+  const [, crossChainQuorums] = await Promise.all([
+    resolveIpfsDescriptions([apiProposal], governanceEnvironment),
+    readCrossChainQuorums([apiProposal], governanceEnvironment),
+  ]);
 
   const formattedData = formatApiProposalData(apiProposal);
-  const crossChainQuorums = await readCrossChainQuorums(
-    [apiProposal],
-    governanceEnvironment,
-  );
   const onChainDataList = await getProposalsOnChainData(
     [apiProposal],
     governanceEnvironment,

--- a/src/actions/governance/proposals/getProposal.ts
+++ b/src/actions/governance/proposals/getProposal.ts
@@ -18,6 +18,7 @@ import {
   getProposalData,
   getProposalsOnChainData,
   isMultichainProposal,
+  readCrossChainQuorums,
 } from "./common.js";
 
 export type GetProposalParameters<
@@ -92,9 +93,14 @@ async function getMoonbeamProposal(
   }
 
   const formattedData = formatApiProposalData(apiProposal);
+  const crossChainQuorums = await readCrossChainQuorums(
+    [apiProposal],
+    governanceEnvironment,
+  );
   const onChainDataList = await getProposalsOnChainData(
     [apiProposal],
     governanceEnvironment,
+    { crossChainQuorums },
   );
   const onChainData = onChainDataList[0]!;
   const isMultichain = isMultichainProposal(apiProposal.targets);

--- a/src/actions/governance/proposals/getProposals.test.ts
+++ b/src/actions/governance/proposals/getProposals.test.ts
@@ -123,6 +123,14 @@ describe("getProposals state post-processing", () => {
     } as unknown as Parameters<typeof getProposals>[1]);
 
     expect(result[0]?.state).toBe(1); // ProposalState.Active
+    // Regression guard against #3: the third argument carrying
+    // `crossChainQuorums` must reach getProposalsOnChainData. A wiring
+    // regression that drops it would still make the state assertion pass.
+    expect(mockedOnChain).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.anything(),
+      expect.objectContaining({ crossChainQuorums: expect.any(Map) }),
+    );
   });
 
   test("EXECUTED state-change forces state=Executed regardless of on-chain state", async () => {

--- a/src/actions/governance/proposals/getProposals.ts
+++ b/src/actions/governance/proposals/getProposals.ts
@@ -6,6 +6,7 @@ import type { Chain, Environment } from "../../../environments/index.js";
 import * as logger from "../../../logger/console.js";
 import { type Proposal, ProposalState } from "../../../types/proposal.js";
 import { type ApiProposal, fetchAllProposals } from "../governor-api-client.js";
+import { resolveIpfsDescriptions } from "../ipfs.js";
 import {
   appendProposalExtendedData,
   formatApiProposalData,
@@ -103,6 +104,8 @@ async function getMoonbeamProposals(
       );
     }
   });
+
+  await resolveIpfsDescriptions(apiProposals);
 
   const crossChainQuorums = await readCrossChainQuorums(
     apiProposals,

--- a/src/actions/governance/proposals/getProposals.ts
+++ b/src/actions/governance/proposals/getProposals.ts
@@ -14,6 +14,7 @@ import {
   getProposalData,
   getProposalsOnChainData,
   isMultichainProposal,
+  readCrossChainQuorums,
 } from "./common.js";
 
 export type GetProposalsParameters<
@@ -103,9 +104,14 @@ async function getMoonbeamProposals(
     }
   });
 
+  const crossChainQuorums = await readCrossChainQuorums(
+    apiProposals,
+    governanceEnvironment,
+  );
   const onChainDataList = await getProposalsOnChainData(
     apiProposals,
     governanceEnvironment,
+    { crossChainQuorums },
   );
 
   const proposals: Proposal[] = apiProposals.map((apiProposal, index) => {

--- a/src/actions/governance/proposals/getProposals.ts
+++ b/src/actions/governance/proposals/getProposals.ts
@@ -95,22 +95,27 @@ async function getMoonbeamProposals(
   const chainsAttempted: ReadonlyArray<1 | 1284> = [1, 1284];
   const apiProposals: ApiProposal[] = [];
   results.forEach((result, index) => {
+    const chainId = chainsAttempted[index];
     if (result.status === "fulfilled") {
       apiProposals.push(...result.value);
-    } else {
+    } else if (chainId !== undefined) {
       console.warn(
-        `[getProposals] Failed to fetch proposals for chainId=${chainsAttempted[index]}; continuing with remaining chains.`,
+        `[getProposals] Failed to fetch proposals for chainId=${chainId}; continuing with remaining chains.`,
         result.reason,
       );
+      governanceEnvironment.onError?.(result.reason, {
+        source: "governance-proposals",
+        chainId,
+      });
     }
   });
 
-  await resolveIpfsDescriptions(apiProposals);
-
-  const crossChainQuorums = await readCrossChainQuorums(
-    apiProposals,
-    governanceEnvironment,
-  );
+  // IPFS resolution and cross-chain quorum reads are independent — run them in
+  // parallel to save one network round-trip on the proposal list path.
+  const [, crossChainQuorums] = await Promise.all([
+    resolveIpfsDescriptions(apiProposals, governanceEnvironment),
+    readCrossChainQuorums(apiProposals, governanceEnvironment),
+  ]);
   const onChainDataList = await getProposalsOnChainData(
     apiProposals,
     governanceEnvironment,

--- a/src/actions/governance/proposals/readCrossChainQuorums.test.ts
+++ b/src/actions/governance/proposals/readCrossChainQuorums.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { Environment } from "../../../environments/index.js";
+import type { ApiProposal } from "../governor-api-client.js";
+
+// Production module-level `publicEnvironments` is replaced with a controllable
+// fixture so tests never touch real RPC.
+const ethQuorum = vi.fn(async () => 1234n);
+const moonbeamQuorum = vi.fn(async () => 500n);
+
+vi.mock("../../../environments/index.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../environments/index.js")>();
+  return {
+    ...actual,
+    publicEnvironments: {
+      ethereum: {
+        chainId: 1,
+        contracts: {
+          multichainGovernor: { read: { quorum: ethQuorum } },
+        },
+      },
+      moonbeam: {
+        chainId: 1284,
+        contracts: {
+          multichainGovernor: { read: { quorum: moonbeamQuorum } },
+        },
+      },
+      base: {
+        // No multichainGovernor wired — should be omitted from the map.
+        chainId: 8453,
+        contracts: {},
+      },
+    },
+  };
+});
+
+const { readCrossChainQuorums } = await import("./common.js");
+
+const proposal = (chainId: number, proposalId: number): ApiProposal =>
+  ({ chainId, proposalId, description: "" }) as unknown as ApiProposal;
+
+const makeEnv = (chainId: number, onError = vi.fn()): Environment =>
+  ({ chainId, onError }) as unknown as Environment;
+
+describe("readCrossChainQuorums", () => {
+  beforeEach(() => {
+    ethQuorum.mockReset().mockResolvedValue(1234n);
+    moonbeamQuorum.mockReset().mockResolvedValue(500n);
+  });
+
+  test("returns an empty map for an empty proposal list", async () => {
+    const out = await readCrossChainQuorums([], makeEnv(1284));
+    expect(out.size).toBe(0);
+    expect(ethQuorum).not.toHaveBeenCalled();
+  });
+
+  test("returns an empty map when every proposal is on the governance env's own chain", async () => {
+    const out = await readCrossChainQuorums(
+      [proposal(1284, 1), proposal(1284, 2)],
+      makeEnv(1284),
+    );
+    expect(out.size).toBe(0);
+    expect(ethQuorum).not.toHaveBeenCalled();
+  });
+
+  test("dedupes multiple proposals on the same foreign chain into one read", async () => {
+    const out = await readCrossChainQuorums(
+      [proposal(1, 1), proposal(1, 2), proposal(1, 3)],
+      makeEnv(1284),
+    );
+    expect(ethQuorum).toHaveBeenCalledTimes(1);
+    expect(out.get(1)).toBe(1234n);
+  });
+
+  test("omits foreign chains whose env has no multichainGovernor wired", async () => {
+    const out = await readCrossChainQuorums(
+      [proposal(8453, 1), proposal(1, 2)],
+      makeEnv(1284),
+    );
+    expect(out.has(8453)).toBe(false);
+    expect(out.get(1)).toBe(1234n);
+  });
+
+  test("omits foreign chains absent from publicEnvironments entirely", async () => {
+    const out = await readCrossChainQuorums(
+      [proposal(99_999, 1), proposal(1, 2)],
+      makeEnv(1284),
+    );
+    expect(out.has(99_999)).toBe(false);
+    expect(out.get(1)).toBe(1234n);
+  });
+
+  test("on quorum() revert: omits the chain, console.warns, and calls env.onError", async () => {
+    const revert = new Error("execution reverted");
+    ethQuorum.mockRejectedValueOnce(revert);
+    const onError = vi.fn();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const out = await readCrossChainQuorums(
+      [proposal(1, 1)],
+      makeEnv(1284, onError),
+    );
+
+    expect(out.has(1)).toBe(false);
+    expect(warnSpy).toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledWith(revert, {
+      source: "governance-cross-chain-quorum",
+      chainId: 1,
+    });
+
+    warnSpy.mockRestore();
+  });
+});

--- a/src/environments/definitions/ethereum/contracts.ts
+++ b/src/environments/definitions/ethereum/contracts.ts
@@ -6,6 +6,7 @@ export const contracts = createContractsConfig({
   contracts: {
     stakingToken: "stkWELL",
     governanceToken: "WELL",
-    views: "0xF5f2ae75d762B7e2B42D53f48018436f52Ce5401",
+    views: "0xA061Ed814bBd1b03e8df0B7AbEbc40f4A6feb895",
+    multichainGovernor: "0x8769B70ac7c93AF0e75de0D69877709B66d75838",
   },
 });

--- a/test/vitest.config.ts
+++ b/test/vitest.config.ts
@@ -45,6 +45,7 @@ export default defineConfig({
       "src/actions/governance/getUserVotingPowers.test.ts",
       "src/actions/governance/getUserVoteReceipt.test.ts",
       "src/actions/governance/governor-api-client.test.ts",
+      "src/actions/governance/ipfs.test.ts",
       "src/actions/governance/proposals/common.test.ts",
       "src/actions/governance/proposals/getProposal.test.ts",
       "src/actions/governance/proposals/getProposals.test.ts",

--- a/test/vitest.config.ts
+++ b/test/vitest.config.ts
@@ -49,6 +49,7 @@ export default defineConfig({
       "src/actions/governance/proposals/common.test.ts",
       "src/actions/governance/proposals/getProposal.test.ts",
       "src/actions/governance/proposals/getProposals.test.ts",
+      "src/actions/governance/proposals/readCrossChainQuorums.test.ts",
       "src/actions/core/user-positions/getUserPositionSnapshots.test.ts",
       "src/client/createMoonwellClient.test.ts",
       "src/common/getBlockNumberAtTimestamp.test.ts",


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                     
                                                                                                                        
  Enables Ethereum mainnet as a first-class governance chain in the SDK:                                                                                                                                                                         
                                         
  - **Full CoreViews wired** on Eth (`0xA061Ed814bBd1b03e8df0B7AbEbc40f4A6feb895`), replacing the staking-only proxy. `getUserVotingPowers` and `getDelegates` now include `mainnet.id` alongside Moonbeam/Base/Optimism.                        
  - **Eth MultichainGovernor exposed** (`0x8769B70ac7c93AF0e75de0D69877709B66d75838`) so frontends can read it from `env.contracts.multichainGovernor` and cast votes on Eth-side multigov proposals (mirrors the Moonbeam wiring).
  - **Cross-chain quorum reads**: `getProposalsOnChainData` now sources quorum for Eth proposals from Eth's `multichainGovernor.quorum()` (via a new `readCrossChainQuorums` helper) instead of returning `0n`. Same-env reads are unchanged.    
  - **IPFS-pinned descriptions resolved**: the indexer now surfaces Eth proposal descriptions as `ipfs://<hash>` URIs. The SDK fetches the markdown from Pinata (`d4529a05.mypinata.cloud`) before subtitle extraction, with an in-memory cache and fail-soft per-proposal error handling.                                                                                                                                                                                                     
                                                                                                                                                                                                                                                 
  ## Test plan                                                                                                                                                                                                                                   
                                                                                                                        
  - [ ] `pnpm typecheck` clean                              
  - [ ] `pnpm vitest run src/actions/governance` passes (new `ipfs.test.ts` + existing proposal tests)
  - [ ] `pnpm lint` clean                                                                                                                                                                                                                        
  - [ ] End-to-end against a known Eth multigov proposal: `getProposal({ proposalId, chainId: 1 })` returns plaintext markdown in `description` and a non-trivial `subtitle`
  - [ ] `getUserVotingPowers({ governanceToken: "WELL", userAddress })` returns an entry with `chainId: 1`                                                                                                                                       
  - [ ] Frontend smoke: cast a vote on an Eth-side proposal via the SDK-exposed `multichainGovernor` 