### PR TITLE
Fix moonbeam vote collector

### DIFF
--- a/.changeset/moonbeam-restore-token-votes-passthrough.md
+++ b/.changeset/moonbeam-restore-token-votes-passthrough.md
@@ -1,0 +1,5 @@
+---
+"@moonwell-fi/moonwell-sdk": patch
+---
+
+Remove the Moonbeam-specific `tokenVotes` mask from `getUserVotingPowers` and `getDelegates`. The Moonbeam `MoonwellViews` implementation was upgraded on-chain to read xWELL for `tokenVotes` (matching Base and Optimism), so the temporary `RAW_WELL_MASKED_CHAINS` workaround is no longer needed. Both actions now return the views response unchanged on Moonbeam, the same as every other chain, so `totalDelegated` once again reflects the user's full xWELL + stkWELL + claims voting power on Moonbeam instead of zeroing the xWELL contribution.

--- a/src/actions/governance/getDelegates.ts
+++ b/src/actions/governance/getDelegates.ts
@@ -9,7 +9,6 @@ import * as logger from "../../logger/console.js";
 import type { Delegate } from "../../types/delegate.js";
 import { getWithRetry } from "../axiosWithRetry.js";
 import { fetchAllVoters } from "./governor-api-client.js";
-import { RAW_WELL_MASKED_CHAINS } from "./votingPolicy.js";
 
 export type GetDelegatesReturnType = Promise<Delegate[]>;
 
@@ -65,17 +64,10 @@ export async function getDelegates(
         const { claimsVotes, stakingVotes, tokenVotes } =
           userVotingPowers[reduceIndex]!;
 
-        // Raw WELL (tokenVotes) is no longer an eligible voting source on
-        // Moonbeam — see comment in getUserVotingPowers.ts. Mask it here so
-        // delegate rankings reflect the new policy.
-        const eligibleTokenVotes = RAW_WELL_MASKED_CHAINS.has(env.chainId)
-          ? 0n
-          : tokenVotes.delegatedVotingPower;
-
         const totalVotes =
           claimsVotes.delegatedVotingPower +
           stakingVotes.delegatedVotingPower +
-          eligibleTokenVotes;
+          tokenVotes.delegatedVotingPower;
 
         votingPower[env.chainId] = Number(totalVotes / BigInt(10 ** 18));
       });

--- a/src/actions/governance/getUserVotingPowers.test.ts
+++ b/src/actions/governance/getUserVotingPowers.test.ts
@@ -1,4 +1,4 @@
-import { type Address, zeroAddress } from "viem";
+import type { Address } from "viem";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { testClient } from "../../../test/client.js";
 import type { MoonwellClient } from "../../client/createMoonwellClient.js";
@@ -254,10 +254,12 @@ describe("getUserVotingPowers — snapshotTimestamp", () => {
     expect(result.map((r) => r.chainId)).toEqual([8453]);
   });
 
-  test("Moonbeam (chainId=1284) zeroes out raw WELL tokenVotes — eligible sources are stkWELL and claims only", async () => {
-    // Simulate a Moonbeam views read where the user has non-zero raw WELL
-    // delegated to themselves, plus non-zero stkWELL and claims voting power.
-    // Per policy, raw WELL must not count toward voting power on Moonbeam.
+  test("Moonbeam (chainId=1284) passes tokenVotes through after the views contract was upgraded to read xWELL", async () => {
+    // The Moonbeam MoonwellViews implementation was upgraded to read xWELL for
+    // tokenVotes (matching Base/OP). The SDK no longer rewrites Moonbeam's
+    // tokenVotes — every source the views returns flows through unmodified.
+    // This test pins that pass-through so a regression to the prior mask
+    // would fail loudly.
     const moonbeamRead = vi.fn(async () => ({
       claimsVotes: {
         delegates: USER,
@@ -294,23 +296,19 @@ describe("getUserVotingPowers — snapshotTimestamp", () => {
     });
 
     expect(result?.chainId).toBe(1284);
-    // Raw WELL is fully masked — every token* field reads as zero.
-    expect(result?.tokenBalance.value).toBe(0);
-    expect(result?.tokenDelegated.value).toBe(0);
-    expect(result?.tokenDelegatedSelf.value).toBe(0);
-    expect(result?.tokenDelegatedOthers.value).toBe(0);
-    expect(result?.tokenUndelegated.value).toBe(0);
-    expect(result?.tokenDelegates).toBe(zeroAddress);
-    // stkWELL + claims pass through untouched.
+    expect(result?.tokenBalance.value).toBe(Number(500n) / 1e18);
+    expect(result?.tokenDelegated.value).toBe(Number(500n) / 1e18);
+    expect(result?.tokenDelegatedSelf.value).toBe(Number(500n) / 1e18);
+    expect(result?.tokenDelegates).toBe(USER);
     expect(result?.stakingDelegated.value).toBe(Number(200n) / 1e18);
     expect(result?.claimsDelegated.value).toBe(Number(100n) / 1e18);
-    // Total excludes the masked tokenVotes (100 + 200 = 300, not 800).
-    expect(result?.totalDelegated.value).toBe(Number(300n) / 1e18);
+    // 100 + 500 + 200 = 800
+    expect(result?.totalDelegated.value).toBe(Number(800n) / 1e18);
   });
 
-  test("non-Moonbeam chains keep raw WELL tokenVotes in voting power", async () => {
-    // Sanity counterpart: the mask is Moonbeam-specific and must NOT bleed
-    // into other chains where raw WELL is still an eligible source.
+  test("non-Moonbeam chains pass tokenVotes through in voting power", async () => {
+    // Positive counterpart to the Moonbeam test above — every chain shares
+    // the same pass-through code path now that the per-chain mask is gone.
     const baseRead = vi.fn(async () => ({
       claimsVotes: {
         delegates: USER,

--- a/src/actions/governance/getUserVotingPowers.ts
+++ b/src/actions/governance/getUserVotingPowers.ts
@@ -8,17 +8,6 @@ import {
 import type { OptionalNetworkParameterType } from "../../common/types.js";
 import type { Chain, GovernanceToken } from "../../environments/index.js";
 import type { UserVotingPowers } from "../../types/userVotingPowers.js";
-import { RAW_WELL_MASKED_CHAINS } from "./votingPolicy.js";
-
-// Raw WELL (even delegated) is no longer an eligible voting source on Moonbeam —
-// eligible voting now flows through stkWELL (stakingVotes) and xWELL only. The
-// Moonbeam views contract still returns a non-zero tokenVotes tuple, so the SDK
-// masks it here to keep `totalDelegated` and the per-source breakdown honest.
-const ZERO_TOKEN_VOTES = {
-  delegates: zeroAddress,
-  votingPower: 0n,
-  delegatedVotingPower: 0n,
-} as const;
 
 const warnedSkippedEnvs = new Set<string>();
 
@@ -108,9 +97,7 @@ export async function getUserVotingPowers<
   );
 
   return resolvedVotingPowers.map(({ env: environment, votingPowers }) => {
-    const tokenVotes = RAW_WELL_MASKED_CHAINS.has(environment.chainId)
-      ? ZERO_TOKEN_VOTES
-      : votingPowers.tokenVotes;
+    const { tokenVotes } = votingPowers;
 
     return {
       chainId: environment.chainId,

--- a/src/actions/governance/votingPolicy.ts
+++ b/src/actions/governance/votingPolicy.ts
@@ -1,9 +1,0 @@
-import { moonbeam } from "viem/chains";
-
-// Chains where raw WELL (`tokenVotes`) is no longer an eligible voting source.
-// Centralized so `getUserVotingPowers` and `getDelegates` consult a single
-// source of truth — if the policy expands or reverses, both call sites move
-// together. See the comment block in `getUserVotingPowers.ts` for the why.
-export const RAW_WELL_MASKED_CHAINS: ReadonlySet<number> = new Set([
-  moonbeam.id,
-]);


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                     
                                                                                                      
  The Moonbeam `MoonwellViews` implementation was upgraded on-chain to read xWELL for `tokenVotes`, matching the pattern Base and Optimism already use. The temporary `RAW_WELL_MASKED_CHAINS` workaround in `getUserVotingPowers` and `getDelegates` is no longer needed — both actions now return the views response unchanged on every multigov chain, so `totalDelegated` once again reflects the user's full xWELL + stkWELL + claims voting power on Moonbeam.
                                                                                                                                                                                                                                                 
  ## Changes                                                                                                                                                                                                                                     
                                                            
  - Delete `src/actions/governance/votingPolicy.ts` (sole consumers updated below).                                                                                                                                                              
  - `getUserVotingPowers.ts`: drop the per-chain mask; `tokenVotes` flows through from the views read.
  - `getDelegates.ts`: drop the `eligibleTokenVotes` branch; `totalVotes` is an unconditional sum.                                                                                                                                               
  - Test: replace the "Moonbeam zeroes out raw WELL" case with a Moonbeam pass-through regression test that pins the new behavior.   