### PR TITLE
fix(ethereum): wire Unitroller as contracts.comptroller

### DIFF
--- a/.changeset/ethereum-comptroller.md
+++ b/.changeset/ethereum-comptroller.md
@@ -1,0 +1,5 @@
+---
+"@moonwell-fi/moonwell-sdk": patch
+---
+
+Wire the Ethereum mainnet Unitroller (`0xdec80bb934397575594e91970b37baf65f5b21be`) as `contracts.comptroller` on the Ethereum environment. Consumers can now call `enterMarkets` / `exitMarket` for the 4 Core markets — without this, the frontend's "Enable as collateral" modal built its `useTransaction` against an undefined contract address, which caused the confirm button to silently no-op (no wallet prompt, no toast, no console error).

--- a/src/environments/definitions/ethereum/contracts.ts
+++ b/src/environments/definitions/ethereum/contracts.ts
@@ -7,6 +7,12 @@ export const contracts = createContractsConfig({
     stakingToken: "stkWELL",
     wrappedNativeToken: "WETH",
     governanceToken: "WELL",
+    // Unitroller proxy fronting the Moonwell Ethereum comptroller. Consumers
+    // call `enterMarkets` / `exitMarket` on this address to enable / disable
+    // a market as collateral; without it the supply page's "Enable as
+    // collateral" modal builds against an undefined contract and silently
+    // no-ops on confirm.
+    comptroller: "0xdec80bb934397575594e91970b37baf65f5b21be",
     views: "0x2d85b9c48a8c582f0AA244e134e9C6f30Cf7786e",
     multichainGovernor: "0x8769B70ac7c93AF0e75de0D69877709B66d75838",
     // mWETHRouter — wraps native ETH to WETH on supply and unwraps WETH to


### PR DESCRIPTION
Adds the Moonwell Ethereum Unitroller (0xdec80bb934397575594e91970b37baf65f5b21be) to the Ethereum env so consumers can call enterMarkets / exitMarket on the 4 Core markets. Without it, the frontend's "Enable as collateral" modal built its useTransaction against an undefined contract address and silently no-op'd on confirm (no wallet prompt, no toast, no console error).