### PR TITLE
ci(governance): voting canary, PR checklist, CODEOWNERS (MOO-351 guards)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Governance-critical paths: classification, routing, and voting-power logic.
+# A misclassification here silently routes votes to dead contracts or hides
+# voting UI (proposal-171 incident, MOO-351). Changes require a review from a
+# governance owner in addition to ordinary review.
+#
+# Owners list is a starting point — adjust in review if ownership should sit
+# elsewhere.
+
+/src/actions/governance/                  @apokusin @bprofiro @lyoungblood
+/src/common/getBlockNumberAtTimestamp.ts  @apokusin @bprofiro @lyoungblood
+/src/environments/definitions/            @apokusin @bprofiro @lyoungblood
+/scripts/governance-canary.mjs            @apokusin @lyoungblood
+/.github/workflows/governance-canary.yml  @apokusin @lyoungblood

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+<!-- Keep the summary short; reviewers read the diff. The checklist below is
+the contract — items exist because skipping them has caused production
+incidents (see MOO-351, the proposal-171 governance outage). -->
+
+## Summary
+
+<!-- What changes and why. Call out public-API impact explicitly. -->
+
+## Checklist
+
+- [ ] **Changeset** added (`pnpm changeset`) if anything consumer-visible changed — including behavioral changes with no signature change (e.g. "no longer rejects, returns partial results").
+- [ ] **Predicate rule**: if this PR adds or changes a predicate/heuristic/classifier (`is*`, `*Aware`, `classify*`, `resolve*Route`), I enumerated its **FALSE branch**: listed the real-world inputs that return false, confirmed each is *supposed* to, and added a test pinning at least one. *(The proposal-171 incident shipped through review because `isMultichainProposal`'s false branch — a hub proposal with no bridge target — was never enumerated.)*
+- [ ] **Misclassification table**: any new heuristic ships with a table (in the PR description or test file) of representative inputs → classification, including at least one input the heuristic is known to get wrong or be uncertain about.
+- [ ] **No silent failures**: no new early-`return` / swallowed catch on a path a user action depends on. Failures either propagate, report via `env.onError`, or are explicitly documented as intentional skips.
+- [ ] **Multi-chain isolation**: any new multi-chain fan-out uses `Promise.allSettled` (or per-chain try/catch) unless all-or-nothing semantics are explicitly required and documented.
+- [ ] **Tests added to the vitest include list** (`test/vitest.config.ts`) — test files not in the array do not run in CI.
+- [ ] `pnpm typecheck`, `pnpm lint`, `pnpm gate:run` pass locally.
+
+## First-of-its-kind inputs
+
+<!-- Does this change handle a NEW input class (new proposal topology, new
+chain, new token, re-enabled feature)? If yes: what exercises that class
+end-to-end before it occurs in production? Link the launch-gate issue. -->

--- a/.github/workflows/governance-canary.yml
+++ b/.github/workflows/governance-canary.yml
@@ -1,0 +1,51 @@
+# Governance canary (MOO-351 follow-up): while any proposal is in its voting
+# window, prove every 15 minutes that it can actually be voted on — correct
+# classification, live castVote route on every chain, snapshot voting power
+# resolving everywhere. The proposal-171 outage ran silently for ~21h; this
+# turns that class of failure into a minutes-to-alert signal.
+#
+# A failed run is the alert (configure repo/org notification routing or wire
+# SLACK_WEBHOOK_URL below to page a channel).
+
+name: governance-canary
+
+on:
+  schedule:
+    - cron: "*/15 * * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  canary:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm build
+
+      - name: Run governance canary
+        env:
+          CANARY_DELEGATE: ${{ vars.CANARY_DELEGATE }}
+        run: node scripts/governance-canary.mjs
+
+      - name: Notify Slack on failure
+        if: failure() && vars.CANARY_SLACK_WEBHOOK != ''
+        env:
+          WEBHOOK: ${{ vars.CANARY_SLACK_WEBHOOK }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          curl -sf -X POST -H 'Content-type: application/json' \
+            --data "{\"text\":\"🚨 governance-canary tripped: a live proposal cannot be voted on. Run: $RUN_URL\"}" \
+            "$WEBHOOK"

--- a/scripts/governance-canary.mjs
+++ b/scripts/governance-canary.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+// Governance canary — proves that every LIVE proposal can actually be voted on.
+//
+// Born from the proposal-171 incident (MOO-351): the first hub-local proposal
+// opened with voting silently broken on every chain for ~21 hours before a
+// user report surfaced it. Prevention failed twice (PR review, launch test);
+// this is the detection layer that does not depend on anyone imagining the
+// failure mode. Runs on a schedule while any proposal is in its voting window.
+//
+// For each Active proposal it asserts:
+//   1. CLASSIFICATION — `proposal.multichain` is consistent with the home
+//      governor (a proposal homed on a hub env that has a multichainGovernor
+//      and no legacy governor MUST be multichain).
+//   2. CASTABILITY — on every chain that renders vote buttons, an eth_call
+//      simulation of `castVote(id, 0)` from a real delegate either succeeds
+//      or reverts INSIDE the governor (recognizable revert data). "Returned
+//      no data (0x)", missing contract, or transport errors fail the canary —
+//      that's the wrong-contract / dead-route signature.
+//   3. VOTING POWER — `getUserVotingPowers` at the proposal snapshot resolves
+//      every governance chain (a missing chain means a chain's read failed —
+//      the bug-B blast-radius signature).
+//
+// Env:
+//   CANARY_DELEGATE  — address with delegated WELL used for simulations
+//                      (default: a known long-standing delegate; override in CI)
+//   RPC_BASE_URL     — RPC prefix (default https://rpc.moonwell.fi/main/evm)
+//
+// Exit code 0 = healthy or nothing live; 1 = canary tripped (workflow alerts).
+
+// No direct viem import: pnpm hoists viem under the `src` package, not the
+// repo root. The SDK environments carry everything needed — a viem
+// PublicClient per chain and contract address/abi pairs.
+import { createMoonwellClient } from "../src/_esm/index.js";
+
+const RPC = process.env.RPC_BASE_URL ?? "https://rpc.moonwell.fi/main/evm";
+const DELEGATE =
+  process.env.CANARY_DELEGATE ?? "0x10b83c88e88910cd5293324800d1a6e751004be5";
+
+const WELL_CHAIN_IDS = [1, 8453, 10, 1284];
+const PROPOSAL_STATE_ACTIVE = 1;
+
+const client = createMoonwellClient({
+  networks: {
+    ethereum: { rpcUrls: [`${RPC}/1`] },
+    base: { rpcUrls: [`${RPC}/8453`] },
+    optimism: { rpcUrls: [`${RPC}/10`] },
+    moonbeam: { rpcUrls: [`${RPC}/1284`] },
+    moonriver: { rpcUrls: [`${RPC}/1285`] },
+  },
+});
+
+const failures = [];
+const fail = (msg) => {
+  failures.push(msg);
+  console.error(`CANARY FAIL: ${msg}`);
+};
+const ok = (msg) => console.log(`canary ok: ${msg}`);
+
+const envByChainId = (chainId) =>
+  Object.values(client.environments).find((e) => e.chainId === chainId);
+
+const isHubHome = (env) =>
+  Boolean(env?.contracts?.multichainGovernor && !env?.contracts?.governor);
+
+// A simulation that reverts INSIDE the governor still proves the route is
+// alive (e.g. "already voted"). What must never happen is the dead-route
+// signature: empty revert data, nonexistent function, or missing contract.
+const isDeadRouteError = (error) => {
+  const text = String(error?.shortMessage ?? error?.message ?? error);
+  return (
+    text.includes("returned no data") ||
+    text.includes('function "castVote" not found') ||
+    text.includes("is not a contract") ||
+    text.includes("HTTP request failed")
+  );
+};
+
+async function checkProposal(proposal) {
+  const id = `${proposal.chainId}-${proposal.proposalId}`;
+  const homeEnv = envByChainId(proposal.chainId);
+
+  // 1. Classification consistency.
+  if (isHubHome(homeEnv) && !proposal.multichain) {
+    fail(
+      `${id}: homed on hub chain ${proposal.chainId} but multichain is unset — vote routing will dead-end (the proposal-171 bug).`,
+    );
+  } else {
+    ok(
+      `${id}: classification consistent (multichain=${Boolean(proposal.multichain)})`,
+    );
+  }
+
+  // 2. Castability on every voting chain.
+  const voteId = BigInt(proposal.multichain?.id ?? proposal.proposalId);
+  for (const chainId of WELL_CHAIN_IDS) {
+    const env = envByChainId(chainId);
+    const target =
+      env?.contracts?.voteCollector ?? env?.contracts?.multichainGovernor;
+    if (!target) {
+      fail(`${id}: chain ${chainId} has no voteCollector/multichainGovernor`);
+      continue;
+    }
+    try {
+      await env.publicClient.simulateContract({
+        address: target.address,
+        abi: target.abi,
+        functionName: "castVote",
+        args: [voteId, 0],
+        account: DELEGATE,
+      });
+      ok(`${id}: castVote simulates on chain ${chainId}`);
+    } catch (error) {
+      if (isDeadRouteError(error)) {
+        fail(
+          `${id}: castVote dead-route on chain ${chainId} via ${target.address}: ${String(error?.shortMessage ?? error?.message).split("\n")[0]}`,
+        );
+      } else {
+        // In-governor revert (already voted / no power on that chain) —
+        // the route is alive, which is what the canary guards.
+        ok(
+          `${id}: castVote reaches governor logic on chain ${chainId} (revert: ${String(error?.shortMessage ?? error?.message).split("\n")[0]})`,
+        );
+      }
+    }
+  }
+
+  // 3. Snapshot voting power resolves on every governance chain.
+  try {
+    const powers = await client.getUserVotingPowers({
+      userAddress: DELEGATE,
+      governanceToken: "WELL",
+      snapshotTimestamp: proposal.startTimestamp,
+    });
+    const got = new Set(powers.map((p) => p.chainId));
+    const missing = WELL_CHAIN_IDS.filter((c) => !got.has(c));
+    if (missing.length > 0) {
+      fail(
+        `${id}: snapshot voting power missing for chain(s) ${missing.join(", ")} — per-chain read failed (bug-B signature).`,
+      );
+    } else {
+      ok(`${id}: snapshot voting power resolves on all ${got.size} chains`);
+    }
+  } catch (error) {
+    fail(
+      `${id}: getUserVotingPowers rejected outright: ${String(error?.shortMessage ?? error?.message).split("\n")[0]}`,
+    );
+  }
+}
+
+const proposals = await client.getProposals();
+const live = proposals.filter((p) => p.state === PROPOSAL_STATE_ACTIVE);
+
+if (live.length === 0) {
+  console.log("canary: no proposals in voting window — nothing to check.");
+  process.exit(0);
+}
+
+console.log(
+  `canary: ${live.length} live proposal(s): ${live.map((p) => p.proposalId).join(", ")}`,
+);
+for (const proposal of live) {
+  await checkProposal(proposal);
+}
+
+if (failures.length > 0) {
+  console.error(`\ncanary TRIPPED — ${failures.length} failure(s).`);
+  process.exit(1);
+}
+console.log("\ncanary healthy.");


### PR DESCRIPTION
## Summary

Detection + review-process guards from the proposal-171 incident ([MOO-351](https://linear.app/moonwell/issue/MOO-351)). Companion to #299 (the root-cause fixes) — independent, mergeable in either order.

### Governance canary (`scripts/governance-canary.mjs` + scheduled workflow)
Every 15 minutes while any proposal is in its voting window, asserts:
1. **Classification** — `proposal.multichain` consistent with the home governor (hub-homed ⇒ multichain)
2. **Castability** — `castVote` eth_call simulation from a real delegate reaches governor logic on every voting chain; dead-route signatures fail (empty revert data, missing function/contract, transport errors)
3. **Voting power** — snapshot `getUserVotingPowers` resolves on every governance chain

**Validated live against proposal 171 (in its voting window right now):**
- On the #299 build → `canary healthy` (castVote simulates on chains 1/8453; in-governor reverts on 10/1284 where the delegate has no power; all 4 chains' voting power resolves)
- On unfixed 0.19.1 → `canary TRIPPED — 2 failures`, catching **both** incident bugs: `multichain is unset — vote routing will dead-end` and `getUserVotingPowers rejected outright: returned no data (0x)`

The incident ran silently for ~21h; this turns the failure class into a ≤15-minute alert. Wire `vars.CANARY_SLACK_WEBHOOK` to page a channel; `vars.CANARY_DELEGATE` overrides the simulation account.

### PR template
Each checklist item maps to a gap that let the incident through review: predicate **FALSE-branch enumeration** (the PR #288 review reprinted the predicate and never considered the no-bridge case), misclassification table, no-silent-failures rule, multi-chain `allSettled` isolation, vitest include-list reminder, changeset-for-behavioral-changes.

### CODEOWNERS
Governance-critical paths require a governance-owner review. Starting owner set (@apokusin @bprofiro @lyoungblood) — **adjust in review** if ownership should sit elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)