### PR TITLE
fix(ethereum): add multiRewardDistributor for reward claims (MOO-413)

### DIFF
--- a/.changeset/moo-413-ethereum-multireward-distributor.md
+++ b/.changeset/moo-413-ethereum-multireward-distributor.md
@@ -1,0 +1,5 @@
+---
+"@moonwell-fi/moonwell-sdk": patch
+---
+
+Add the Ethereum `multiRewardDistributor` (MRD_PROXY `0x60142B8d76FaC5b88cfB422Ba1aA905d2171851c`, the comptroller's `rewardDistributor()`) to the Ethereum environment config, mirroring Base and Optimism (MOO-413). The SDK derives reward APRs from the `views` contract, but the frontend's reward-claim flow branches on this address: when present it claims via the comptroller's `claimReward`, and when absent it falls back to the Moonbeam `0x…0808` precompile `batchAll` path, which reverts on Ethereum. Without it, the WELL rewards MIP-X59 starts accruing on the four Ethereum Core markets (ETH, USDC, USDT, cbBTC) would be displayed but not claimable.

--- a/src/environments/definitions/ethereum/contracts.ts
+++ b/src/environments/definitions/ethereum/contracts.ts
@@ -14,6 +14,15 @@ export const contracts = createContractsConfig({
     // no-ops on confirm.
     comptroller: "0xdec80bb934397575594e91970b37baf65f5b21be",
     views: "0x2d85b9c48a8c582f0AA244e134e9C6f30Cf7786e",
+    // MultiRewardDistributor (MRD_PROXY, deployed with MIP-E00) — the
+    // comptroller's `rewardDistributor()`. Reward *APRs* come from the `views`
+    // contract / indexer, not this address; what needs it is the app's
+    // reward-claim flow (useUserRewardsData), which keys off its presence:
+    // defined ⇒ claim via the comptroller's `claimReward(holders, mTokens, …)`
+    // (the EVM path Base/Optimism use), absent ⇒ fall back to the Moonbeam
+    // `0x…0808` precompile `batchAll`, which reverts on Ethereum. Required so
+    // users can claim the WELL rewards MIP-X59 starts accruing on Core markets.
+    multiRewardDistributor: "0x60142B8d76FaC5b88cfB422Ba1aA905d2171851c",
     multichainGovernor: "0x8769B70ac7c93AF0e75de0D69877709B66d75838",
     // mWETHRouter — wraps native ETH to WETH on supply and unwraps WETH to
     // native ETH on withdraw, matching the mWETHRouter pattern used on Base

--- a/src/environments/definitions/ethereum/environment.test.ts
+++ b/src/environments/definitions/ethereum/environment.test.ts
@@ -74,6 +74,24 @@ describe("ethereum environment invariants", () => {
     expect(Object.keys(env.config.markets)).toHaveLength(4);
   });
 
+  // Ethereum's MultiRewardDistributor (the comptroller's `rewardDistributor()`,
+  // MRD_PROXY from MIP-E00) was historically omitted from this config. The SDK
+  // never reads it directly (reward APRs come from the `views` contract), but
+  // the frontend's reward-claim flow branches on its presence — absent, an
+  // Ethereum claim falls back to the Moonbeam `0x…0808` precompile path and
+  // reverts. Lock the address so dropping it fails CI rather than silently
+  // re-breaking claims (mirrors the Base/Optimism convention of defining it).
+  test("multiRewardDistributor is wired with the on-chain MRD_PROXY address", () => {
+    const env = createEnvironment();
+
+    expect(env.config.contracts.multiRewardDistributor).toBe(
+      "0x60142B8d76FaC5b88cfB422Ba1aA905d2171851c",
+    );
+    expect(env.contracts.multiRewardDistributor.address).toBe(
+      "0x60142B8d76FaC5b88cfB422Ba1aA905d2171851c",
+    );
+  });
+
   // No `publicEnvironments` entry may list `moonbeam.id` in
   // `custom.governance.chainIds` — that field is consumed as a `homeEnvironment`
   // membership predicate by core/markets/user-rewards (see


### PR DESCRIPTION
## Summary

Adds the Ethereum `multiRewardDistributor` (`MRD_PROXY` = `0x60142B8d76FaC5b88cfB422Ba1aA905d2171851c`) to `src/environments/definitions/ethereum/contracts.ts`, mirroring the Base and Optimism configs. Closes [MOO-413](https://linear.app/moonwell/issue/MOO-413).

## Why (the real reason — not what the ticket says)

The ticket claimed the missing address would make reward **APRs display as 0%**. That's inaccurate — reward APRs come from the on-chain `views` contract / Lunar indexer, and the SDK never reads `multiRewardDistributor` directly.

The actual consumer is the **frontend** `useUserRewardsData.tsx`, which branches on this address to build the reward-**claim** transaction:

| `multiRewardDistributor` defined? | Claim routes to | ABI / fn |
| --- | --- | --- |
| Yes (Base, OP) | `comptroller.address` | `claimReward(holders, mTokens, …)` |
| No (Moonbeam/Moonriver) | `0x…0808` precompile | `batchAll(…)` |

Ethereum, lacking it, fell into the Moonbeam precompile path — a claim tx to `0x…0808` on Ethereum mainnet reverts. So once MIP-X59 makes WELL accrue on the four Ethereum Core markets (ETH, USDC, USDT, cbBTC), users would see rewards but **fail to claim** them. No frontend change needed — the frontend already branches on the value; this just supplies it.

## Verification

- **Address verified on-chain:** `Comptroller(0xdec80bb…21be).rewardDistributor()` on Ethereum mainnet returns exactly `0x60142B8d76FaC5b88cfB422Ba1aA905d2171851c`.
- `pnpm typecheck` clean · `pnpm lint` clean.
- Full suite green (33 files / 550 tests); `getUserRewards` live-RPC cases for Ethereum pass.
- Quality gate: **PASS** (no regression).

## Tests added

- `src/environments/definitions/ethereum/environment.test.ts` — locks both `env.config.contracts.multiRewardDistributor` (raw config) and `env.contracts.multiRewardDistributor.address` (wired viem contract), so dropping or mis-wiring the address fails CI. This closes the coverage gap that let the omission ship originally.

## Notes / follow-ups

- Latent type gap (out of scope here): `multiRewardDistributor` is `?: Address` (optional) in the config type but treated as required in the client contract type — which is why this could ship missing on Ethereum without a compile error. Worth tightening separately.
- The Linear ticket's description should be updated to say this fixes reward **claim** routing, not APR display.