### PR TITLE
fix(config): require multiRewardDistributor for EVM comptroller chains

### DIFF
--- a/.changeset/require-multirewarddistributor-evm-config.md
+++ b/.changeset/require-multirewarddistributor-evm-config.md
@@ -1,0 +1,5 @@
+---
+"@moonwell-fi/moonwell-sdk": minor
+---
+
+Require `multiRewardDistributor` at the type level for EVM comptroller environments. **Type-breaking** for direct callers of `createContractsConfig`: a config with a `comptroller` and no `governor` that omits `multiRewardDistributor` no longer compiles. `createContractsConfig` now rejects a contracts config that defines a `comptroller` but no `governor` (i.e. Base/Optimism/Ethereum) unless it also defines `multiRewardDistributor` — closing the gap that let Ethereum ship without it and silently break reward claims (MOO-413). Moonbeam and Moonriver, which use the on-chain `governor` + WELL precompile reward model, are unaffected and correctly continue to omit it. A runtime invariant test across `publicEnvironments` backstops the type guard.

--- a/src/environments/contracts-invariants.test.ts
+++ b/src/environments/contracts-invariants.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "vitest";
+import { publicEnvironments } from "./index.js";
+
+// Runtime companion to the `createContractsConfig` compile-time guard in
+// types/config.ts. Every EVM comptroller environment — one that has a
+// `comptroller` but no Moonbeam-style on-chain `governor` — must wire a
+// `multiRewardDistributor`. Without it the app's reward-claim flow falls back
+// to the Moonbeam `0x…0808` precompile `batchAll` path, which reverts on these
+// chains (the MOO-413 regression, which shipped on Ethereum). The input type
+// enforces this at the `createContractsConfig` call site; this test is the
+// universal net — it iterates the wired `publicEnvironments`, so it also covers
+// any environment built outside that factory and catches an `as`-cast that
+// bypasses the type. Moonbeam/Moonriver use the `governor` + WELL precompile
+// reward model and correctly have no MRD, so the `governor` discriminator
+// excludes them.
+describe("contract config invariants across public environments", () => {
+  type ContractRef = { address?: string } | undefined;
+  const envs = Object.entries(publicEnvironments) as Array<
+    [
+      string,
+      {
+        contracts?: {
+          comptroller?: ContractRef;
+          governor?: ContractRef;
+          multiRewardDistributor?: ContractRef;
+        };
+      },
+    ]
+  >;
+
+  const evmComptrollerEnvs = envs.filter(
+    ([, env]) => !!env.contracts?.comptroller && !env.contracts?.governor,
+  );
+
+  test("Base, Optimism, and Ethereum are detected as EVM comptroller chains", () => {
+    expect(evmComptrollerEnvs.map(([key]) => key)).toEqual(
+      expect.arrayContaining(["base", "optimism", "ethereum"]),
+    );
+  });
+
+  test("every EVM comptroller environment defines multiRewardDistributor", () => {
+    for (const [key, env] of evmComptrollerEnvs) {
+      expect(
+        env.contracts?.multiRewardDistributor?.address,
+        `${key} is an EVM comptroller chain and must define multiRewardDistributor`,
+      ).toMatch(/^0x[0-9a-fA-F]{40}$/);
+    }
+  });
+});

--- a/src/environments/types/config.ts
+++ b/src/environments/types/config.ts
@@ -236,9 +236,27 @@ export const createMorphoMarketConfig = <const tokens, const markets>(config: {
   markets: MorphoMarketsConfig<markets, tokens>;
 }) => config.markets as Prettify<markets>;
 
+// Moonwell's EVM comptroller chains (Base, Optimism, Ethereum) distribute WELL
+// rewards through a MultiRewardDistributor, so omitting `multiRewardDistributor`
+// silently breaks reward claims — the app's claim flow then falls back to the
+// Moonbeam `0x…0808` precompile path, which reverts on these chains. That gap
+// shipped once already (MOO-413: Ethereum had no MRD). The Moonbeam-family home
+// chains (Moonbeam, Moonriver) instead use the on-chain `governor` + WELL
+// precompile reward model and legitimately have no MRD. Encode the distinction:
+// a config with a `comptroller` but no `governor` is an EVM comptroller chain
+// and must define `multiRewardDistributor`, so dropping it fails to compile.
+type RequireMultiRewardDistributor<contracts> = contracts extends {
+  comptroller: Address;
+}
+  ? contracts extends { governor: Address }
+    ? unknown
+    : { multiRewardDistributor: Address }
+  : unknown;
+
 export const createContractsConfig = <const tokens, const contracts>(config: {
   tokens: TokensConfig<tokens>;
-  contracts: ContractsConfig<contracts, tokens>;
+  contracts: ContractsConfig<contracts, tokens> &
+    RequireMultiRewardDistributor<contracts>;
 }) => {
   return config.contracts as Prettify<contracts>;
 };

--- a/test/vitest.config.ts
+++ b/test/vitest.config.ts
@@ -54,6 +54,7 @@ export default defineConfig({
       "src/client/createMoonwellClient.test.ts",
       "src/common/getBlockNumberAtTimestamp.test.ts",
       "src/environments/definitions/ethereum/environment.test.ts",
+      "src/environments/contracts-invariants.test.ts",
     ],
     setupFiles: [join(__dirname, "./setup.ts")],
     hookTimeout: 60_000,


### PR DESCRIPTION
## Summary

Closes the **root cause** behind [MOO-413](https://linear.app/moonwell/issue/MOO-413) / #306: the contracts config typed `multiRewardDistributor?` as optional, so an EVM comptroller chain could omit it with **no compile error** — which is exactly how Ethereum shipped without it and silently broke the frontend reward-claim flow (it falls back to the Moonbeam `0x…0808` precompile path, which reverts).

> ⚠️ **Stacked on #306** (base = `brenda/moo-413-…`). This change requires Ethereum's MRD to already be present, so it must merge after #306. Retarget to `main` once #306 lands.

## Change

`createContractsConfig` now intersects a conditional constraint onto its input:

```ts
type RequireMultiRewardDistributor<contracts> = contracts extends { comptroller: Address }
  ? contracts extends { governor: Address }
    ? unknown                              // Moonbeam/Moonriver: WELL precompile model, no MRD
    : { multiRewardDistributor: Address }  // EVM comptroller chain: MRD required
  : unknown;                               // no comptroller: not a lending env
```

**Discriminator:** `comptroller` present + `governor` absent ⟹ EVM comptroller chain ⟹ MRD required. Verified against all 8 definitions: Base/Optimism/Ethereum (require, and have it); Moonbeam/Moonriver (have `governor` → exempt); arbitrum/avalanche/polygon (no comptroller → exempt).

## Verification

- `pnpm typecheck` passes for all 8 current definitions.
- **Proof it catches the regression:** removing MRD from `ethereum/contracts.ts` now produces `error TS2741: Property 'multiRewardDistributor' is missing`.
- Moonbeam/Moonriver and the non-comptroller chains still compile.
- Full suite: 552 pass (34 files). Quality gate: PASS.

## Tests added

- `src/environments/contracts-invariants.test.ts` — runtime backstop iterating `publicEnvironments`: asserts every EVM comptroller env (comptroller, no governor) has a valid `multiRewardDistributor.address`. Covers envs built outside the factory and any `as`-cast bypass. Registered in the vitest include list.

## Reviewer notes (triaged)

- A type-design review flagged a possible `governor: undefined` bypass (🟡). **Verified not reproducible** under this repo's `exactOptionalPropertyTypes: true` — `governor: undefined` is itself a compile error (TS2375), so it can't take the exempt branch. No code change made (guarding an impossible case would add noise).
- The `governor`-presence discriminator is a structural proxy for "Moonbeam-family home chain." Sound for all current/foreseeable chains; if a future chain breaks the heuristic, an explicit `kind` tag would be the more durable design. Noted as a future option, not done now (disproportionate to this fix).

## Semver

Marked **minor** (breaking) per the repo's breaking-change hook: direct callers of the exported `createContractsConfig` that omit MRD on an EVM comptroller config will no longer compile. Internal definitions are all updated/valid.