### PR TITLE
Route Merkl API calls through the lunar-indexer proxy (MOO-490)

### DIFF
--- a/.changeset/merkl-proxy-through-lunar-indexer.md
+++ b/.changeset/merkl-proxy-through-lunar-indexer.md
@@ -1,0 +1,7 @@
+---
+"@moonwell-fi/moonwell-sdk": patch
+---
+
+Route Merkl API calls through the lunar-indexer worker proxy instead of hitting `api.merkl.xyz` directly.
+
+Merkl's v4 API needs a server-side API key for production rate limits, which the browser-side SDK cannot hold. Merkl campaign IDs, stkWELL staking APR, and Morpho/staking user rewards are now fetched from the lunar-indexer worker's `/api/v1/merkl` proxy (derived from each environment's `lunarIndexerUrl`), which injects the key and passes the query and response through unchanged. No public API changes — request/response shapes are identical. Consumers that enforce a network/CSP allowlist should ensure the lunar-indexer worker host is permitted (it is already used for other SDK data).

--- a/package.json
+++ b/package.json
@@ -69,7 +69,9 @@
       "ignoreMissing": ["node-fetch"]
     },
     "overrides": {
-      "@biconomy/abstractjs": "1.0.18"
+      "@biconomy/abstractjs": "1.0.18",
+      "ws@>=8.0.0 <8.21.0": ">=8.21.0",
+      "form-data@>=4.0.0 <4.0.6": ">=4.0.6"
     }
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,8 @@ settings:
 
 overrides:
   '@biconomy/abstractjs': 1.0.18
+  ws@>=8.0.0 <8.21.0: '>=8.21.0'
+  form-data@>=4.0.0 <4.0.6: '>=4.0.6'
 
 importers:
 
@@ -3507,8 +3509,8 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   format@0.2.2:
@@ -3644,6 +3646,10 @@ packages:
 
   hasown@2.0.3:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   hast-util-classnames@3.0.0:
@@ -3889,7 +3895,7 @@ packages:
   isows@1.0.7:
     resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
     peerDependencies:
-      ws: '*'
+      ws: '>=8.21.0'
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -5803,20 +5809,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.18.3:
-    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -8362,7 +8356,7 @@ snapshots:
   axios@1.16.0:
     dependencies:
       follow-redirects: 1.16.0
-      form-data: 4.0.5
+      form-data: 4.0.6
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
@@ -8943,7 +8937,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.3
+      hasown: 2.0.4
 
   es-toolkit@1.47.0: {}
 
@@ -9213,12 +9207,12 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.3
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   format@0.2.2: {}
@@ -9275,7 +9269,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.3
+      hasown: 2.0.4
       math-intrinsics: 1.1.0
 
   get-nonce@1.0.1: {}
@@ -9347,6 +9341,10 @@ snapshots:
       has-symbols: 1.1.0
 
   hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 
@@ -9660,9 +9658,9 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  isows@1.0.7(ws@8.18.3):
+  isows@1.0.7(ws@8.21.0):
     dependencies:
-      ws: 8.18.3
+      ws: 8.21.0
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -9731,7 +9729,7 @@ snapshots:
       cssstyle: 4.6.0
       data-urls: 5.0.0
       decimal.js: 10.6.0
-      form-data: 4.0.5
+      form-data: 4.0.6
       html-encoding-sniffer: 4.0.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -9747,7 +9745,7 @@ snapshots:
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
-      ws: 8.20.0
+      ws: 8.21.0
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -11826,9 +11824,9 @@ snapshots:
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@5.9.3)(zod@4.4.3)
-      isows: 1.0.7(ws@8.18.3)
+      isows: 1.0.7(ws@8.21.0)
       ox: 0.14.20(typescript@5.9.3)(zod@4.4.3)
-      ws: 8.18.3
+      ws: 8.21.0
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -12115,9 +12113,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.18.3: {}
-
-  ws@8.20.0: {}
+  ws@8.21.0: {}
 
   xml-name-validator@5.0.0: {}
 

--- a/src/actions/governance/common.ts
+++ b/src/actions/governance/common.ts
@@ -1,5 +1,6 @@
 import type { Address } from "viem";
 import { MOONWELL_FETCH_JSON_HEADERS } from "../../common/fetch-headers.js";
+import { getMerklProxyBaseUrl } from "../../common/lunar-indexer-helpers.js";
 
 type MerklRewardsResponse = {
   chain: {
@@ -84,7 +85,9 @@ export function resetMerklCampaignIdsCache(): void {
  * Fetches all Moonwell Merkl campaign IDs from the API.
  * Results are cached in memory for 4 hours since campaigns only change monthly.
  */
-export async function getMerklCampaignIds(): Promise<string[]> {
+export async function getMerklCampaignIds(
+  lunarIndexerUrl?: string,
+): Promise<string[]> {
   const now = Date.now();
   if (
     campaignIdsCache !== null &&
@@ -95,7 +98,7 @@ export async function getMerklCampaignIds(): Promise<string[]> {
 
   try {
     const response = await fetch(
-      `https://api.merkl.xyz/v4/campaigns?creatorAddress=${MOONWELL_MERKL_CREATOR}&excludeSubCampaigns=true&items=100`,
+      `${getMerklProxyBaseUrl(lunarIndexerUrl)}/campaigns?creatorAddress=${MOONWELL_MERKL_CREATOR}&excludeSubCampaigns=true&items=100`,
       { headers: MOONWELL_FETCH_JSON_HEADERS },
     );
 
@@ -120,10 +123,12 @@ export async function getMerklRewardsData(
   campaignId: string[],
   chainId: number,
   account: Address,
+  lunarIndexerUrl?: string,
 ): Promise<MerklReward[]> {
+  const merklProxyBaseUrl = getMerklProxyBaseUrl(lunarIndexerUrl);
   try {
     const page0Response = await fetch(
-      `https://api.merkl.xyz/v4/users/${account}/rewards?chainId=${chainId}&test=false&breakdownPage=0&reloadChainId=${chainId}`,
+      `${merklProxyBaseUrl}/users/${account}/rewards?chainId=${chainId}&test=false&breakdownPage=0&reloadChainId=${chainId}`,
       {
         headers: MOONWELL_FETCH_JSON_HEADERS,
       },
@@ -145,7 +150,7 @@ export async function getMerklRewardsData(
     // Paginate through remaining breakdown pages to collect all breakdowns
     for (let page = 1; page < MAX_BREAKDOWN_PAGES; page++) {
       const pageResponse = await fetch(
-        `https://api.merkl.xyz/v4/users/${account}/rewards?chainId=${chainId}&test=false&breakdownPage=${page}&reloadChainId=${chainId}`,
+        `${merklProxyBaseUrl}/users/${account}/rewards?chainId=${chainId}&test=false&breakdownPage=${page}&reloadChainId=${chainId}`,
         {
           headers: MOONWELL_FETCH_JSON_HEADERS,
         },
@@ -214,12 +219,13 @@ export async function getMerklRewardsData(
 
 export async function getMerklStakingApr(
   contractAddress: string,
+  lunarIndexerUrl?: string,
 ): Promise<number> {
   const now = Math.floor(Date.now() / 1000);
 
   try {
     const response = await fetch(
-      `https://api.merkl.xyz/v4/campaigns?creatorAddress=${MOONWELL_MERKL_CREATOR}&excludeSubCampaigns=true&items=100`,
+      `${getMerklProxyBaseUrl(lunarIndexerUrl)}/campaigns?creatorAddress=${MOONWELL_MERKL_CREATOR}&excludeSubCampaigns=true&items=100`,
       { headers: MOONWELL_FETCH_JSON_HEADERS },
     );
 

--- a/src/actions/governance/common.ts
+++ b/src/actions/governance/common.ts
@@ -89,6 +89,9 @@ export async function getMerklCampaignIds(
   lunarIndexerUrl?: string,
 ): Promise<string[]> {
   const now = Date.now();
+  // The cache intentionally ignores `lunarIndexerUrl`: the Moonwell campaign set
+  // is the same regardless of which proxy host serves it, so a differing URL
+  // within the TTL still returns the cached IDs.
   if (
     campaignIdsCache !== null &&
     now - campaignIdsCache.fetchedAt < CAMPAIGN_IDS_CACHE_TTL_MS

--- a/src/actions/governance/getMerklRewardsData.test.ts
+++ b/src/actions/governance/getMerklRewardsData.test.ts
@@ -170,6 +170,24 @@ describe("getMerklRewardsData", () => {
     expect(result[0]!.token.symbol).toBe("WELL");
   });
 
+  test("calls the lunar-indexer Merkl proxy, not api.merkl.xyz directly", async () => {
+    mockFetchResponses([{ ok: true, data: makeEmptyBreakdownResponse() }]);
+
+    const account = "0x1234567890abcdef1234567890abcdef12345678";
+    await getMerklRewardsData(
+      [CAMPAIGN_A],
+      8453,
+      account,
+      "https://indexer.test",
+    );
+
+    const calledUrl = vi.mocked(fetch).mock.calls[0]?.[0];
+    expect(calledUrl).toBe(
+      `https://indexer.test/api/v1/merkl/users/${account}/rewards?chainId=8453&test=false&breakdownPage=0&reloadChainId=8453`,
+    );
+    expect(calledUrl).not.toContain("api.merkl.xyz");
+  });
+
   test("finds breakdowns on page 1 when not on page 0", async () => {
     mockFetchResponses([
       // Page 0: breakdowns that don't match target campaigns
@@ -558,6 +576,18 @@ describe("getMerklCampaignIds", () => {
     expect(fetch).toHaveBeenCalledTimes(1);
   });
 
+  test("calls the lunar-indexer Merkl proxy for campaigns", async () => {
+    mockFetchResponses([
+      { ok: true, data: makeCampaignsResponse([{ campaignId: CAMPAIGN_A }]) },
+    ]);
+
+    await getMerklCampaignIds("https://indexer.test");
+
+    const calledUrl = vi.mocked(fetch).mock.calls[0]?.[0];
+    expect(calledUrl).toContain("https://indexer.test/api/v1/merkl/campaigns");
+    expect(calledUrl).not.toContain("api.merkl.xyz");
+  });
+
   test("returns cached result on second call", async () => {
     mockFetchResponses([
       {
@@ -656,6 +686,16 @@ describe("getMerklStakingApr", () => {
     const result = await getMerklStakingApr(STKWELL_ADDRESS);
 
     expect(result).toBe(12.5);
+  });
+
+  test("calls the lunar-indexer Merkl proxy for campaigns", async () => {
+    mockFetchResponses([{ ok: true, data: [] }]);
+
+    await getMerklStakingApr(STKWELL_ADDRESS, "https://indexer.test");
+
+    const calledUrl = vi.mocked(fetch).mock.calls[0]?.[0];
+    expect(calledUrl).toContain("https://indexer.test/api/v1/merkl/campaigns");
+    expect(calledUrl).not.toContain("api.merkl.xyz");
   });
 
   test("sums APRs when multiple campaigns for the same token are live", async () => {

--- a/src/actions/governance/getMerklRewardsData.test.ts
+++ b/src/actions/governance/getMerklRewardsData.test.ts
@@ -588,6 +588,19 @@ describe("getMerklCampaignIds", () => {
     expect(calledUrl).not.toContain("api.merkl.xyz");
   });
 
+  test("falls back to the production lunar-indexer worker when no URL is given", async () => {
+    mockFetchResponses([
+      { ok: true, data: makeCampaignsResponse([{ campaignId: CAMPAIGN_A }]) },
+    ]);
+
+    await getMerklCampaignIds();
+
+    const calledUrl = vi.mocked(fetch).mock.calls[0]?.[0];
+    expect(calledUrl).toBe(
+      "https://lunar-services-worker.moonwell.workers.dev/api/v1/merkl/campaigns?creatorAddress=0x8b621804a7637b781e2BbD58e256a591F2dF7d51&excludeSubCampaigns=true&items=100",
+    );
+  });
+
   test("returns cached result on second call", async () => {
     mockFetchResponses([
       {

--- a/src/actions/governance/getStakingInfo.ts
+++ b/src/actions/governance/getStakingInfo.ts
@@ -207,7 +207,7 @@ export async function getStakingInfo<
     ? baseTokens?.[baseStakingTokenKey]?.address
     : undefined;
   const baseStakingApr = baseStkTokenAddress
-    ? await getMerklStakingApr(baseStkTokenAddress)
+    ? await getMerklStakingApr(baseStkTokenAddress, baseEnv?.lunarIndexerUrl)
     : 0;
 
   const result = envsWithStaking.flatMap((curr, index) => {

--- a/src/actions/governance/getUserStakingInfo.ts
+++ b/src/actions/governance/getUserStakingInfo.ts
@@ -186,11 +186,14 @@ export async function getUserStakingInfo<
     }),
   );
 
-  const campaignIds = await getMerklCampaignIds();
+  const campaignIds = await getMerklCampaignIds(
+    baseEnvironment?.lunarIndexerUrl,
+  );
   const merklRewards = await getMerklRewardsData(
     campaignIds,
     base.id,
     userAddress,
+    baseEnvironment?.lunarIndexerUrl,
   );
 
   const result = envsWithStaking.flatMap((curr, index) => {

--- a/src/actions/morpho/user-rewards/common.test.ts
+++ b/src/actions/morpho/user-rewards/common.test.ts
@@ -216,7 +216,7 @@ describe("getUserMorphoRewardsData", () => {
     expect(merklError.status).toBe(500);
     expect(merklError.statusText).toBe("Internal Server Error");
     expect(merklError.chainId).toBe(8453);
-    expect(merklError.url).toContain("api.merkl.xyz");
+    expect(merklError.url).toContain("/api/v1/merkl/");
     expect(merklError.message).toContain("chain 8453");
     expect(merklError.message).toContain("500");
   });
@@ -244,7 +244,7 @@ describe("getUserMorphoRewardsData", () => {
     expect(merklError.chainId).toBe(8453);
     expect(merklError.status).toBeUndefined();
     expect(merklError.statusText).toBeUndefined();
-    expect(merklError.url).toContain("api.merkl.xyz");
+    expect(merklError.url).toContain("/api/v1/merkl/");
     expect(merklError.message).toContain("network error");
     expect(merklError.cause).toBe(networkError);
   });

--- a/src/actions/morpho/user-rewards/common.ts
+++ b/src/actions/morpho/user-rewards/common.ts
@@ -1,6 +1,7 @@
 import { type Address, getContract, parseAbi, zeroAddress } from "viem";
 import { Amount } from "../../../common/amount.js";
 import { MOONWELL_FETCH_JSON_HEADERS } from "../../../common/fetch-headers.js";
+import { getMerklProxyBaseUrl } from "../../../common/lunar-indexer-helpers.js";
 import {
   type Environment,
   type TokenConfig,
@@ -339,7 +340,7 @@ async function getMerklRewardsData(
   account: Address,
   options: { throwOnError: boolean } = { throwOnError: false },
 ): Promise<MerklRewardsResponse[]> {
-  const url = `https://api.merkl.xyz/v4/users/${account}/rewards?chainId=${environment.chainId}&test=false&breakdownPage=0&reloadChainId=${environment.chainId}`;
+  const url = `${getMerklProxyBaseUrl(environment.lunarIndexerUrl)}/users/${account}/rewards?chainId=${environment.chainId}&test=false&breakdownPage=0&reloadChainId=${environment.chainId}`;
 
   let response: Response;
   try {

--- a/src/common/lunar-indexer-helpers.ts
+++ b/src/common/lunar-indexer-helpers.ts
@@ -3,6 +3,30 @@
  */
 
 /**
+ * Default lunar-indexer worker URL, used when an environment has no
+ * `lunarIndexerUrl` configured. Mirrors the default in the environment
+ * definitions so Merkl calls still resolve to the production proxy.
+ */
+const DEFAULT_LUNAR_INDEXER_URL =
+  "https://lunar-services-worker.moonwell.workers.dev";
+
+/**
+ * Build the base URL for the Merkl proxy exposed by the lunar-indexer worker.
+ *
+ * Merkl's v4 API needs a server-side API key for production rate limits, and
+ * the SDK runs in the browser where it cannot hold that secret. So all Merkl
+ * requests go through the worker's `/api/v1/merkl` proxy, which injects the key
+ * and passes the query/response through unchanged.
+ *
+ * @param lunarIndexerUrl - The environment's lunar-indexer base URL (falls back
+ *   to the production worker when undefined)
+ * @returns The Merkl proxy base URL, with no trailing slash
+ */
+export function getMerklProxyBaseUrl(lunarIndexerUrl?: string): string {
+  return `${lunarIndexerUrl ?? DEFAULT_LUNAR_INDEXER_URL}/api/v1/merkl`;
+}
+
+/**
  * Build a marketId string from chainId and market address
  * Format: {chainId}-{marketAddress}
  * @param chainId - The chain ID

--- a/src/common/lunar-indexer-helpers.ts
+++ b/src/common/lunar-indexer-helpers.ts
@@ -4,10 +4,10 @@
 
 /**
  * Default lunar-indexer worker URL, used when an environment has no
- * `lunarIndexerUrl` configured. Mirrors the default in the environment
- * definitions so Merkl calls still resolve to the production proxy.
+ * `lunarIndexerUrl` configured. Shared with the environment definitions so the
+ * production host has a single source of truth.
  */
-const DEFAULT_LUNAR_INDEXER_URL =
+export const DEFAULT_LUNAR_INDEXER_URL =
   "https://lunar-services-worker.moonwell.workers.dev";
 
 /**
@@ -18,12 +18,14 @@ const DEFAULT_LUNAR_INDEXER_URL =
  * requests go through the worker's `/api/v1/merkl` proxy, which injects the key
  * and passes the query/response through unchanged.
  *
- * @param lunarIndexerUrl - The environment's lunar-indexer base URL (falls back
- *   to the production worker when undefined)
+ * @param lunarIndexerUrl - The environment's lunar-indexer base URL. Falls back
+ *   to the production worker when missing or empty, so Merkl always resolves.
  * @returns The Merkl proxy base URL, with no trailing slash
  */
 export function getMerklProxyBaseUrl(lunarIndexerUrl?: string): string {
-  return `${lunarIndexerUrl ?? DEFAULT_LUNAR_INDEXER_URL}/api/v1/merkl`;
+  // `||` (not `??`) so an empty-string misconfig also falls back rather than
+  // producing a host-less `/api/v1/merkl/...` URL.
+  return `${lunarIndexerUrl || DEFAULT_LUNAR_INDEXER_URL}/api/v1/merkl`;
 }
 
 /**

--- a/src/environments/definitions/base/environment.ts
+++ b/src/environments/definitions/base/environment.ts
@@ -1,5 +1,6 @@
 import { http, defineChain, fallback } from "viem";
 import { base as baseChain } from "viem/chains";
+import { DEFAULT_LUNAR_INDEXER_URL } from "../../../common/lunar-indexer-helpers.js";
 import {
   type Environment,
   createEnvironmentConfig,
@@ -39,8 +40,7 @@ const createEnvironment = (
     governanceIndexerUrl:
       governanceIndexerUrl ||
       "https://lunar-services-worker.moonwell.workers.dev",
-    lunarIndexerUrl:
-      lunarIndexerUrl || "https://lunar-services-worker.moonwell.workers.dev",
+    lunarIndexerUrl: lunarIndexerUrl || DEFAULT_LUNAR_INDEXER_URL,
     tokens,
     markets,
     vaults,

--- a/src/environments/definitions/ethereum/environment.ts
+++ b/src/environments/definitions/ethereum/environment.ts
@@ -1,5 +1,6 @@
 import { http, defineChain, fallback } from "viem";
 import { mainnet } from "viem/chains";
+import { DEFAULT_LUNAR_INDEXER_URL } from "../../../common/lunar-indexer-helpers.js";
 import {
   type Environment,
   createEnvironmentConfig,
@@ -39,8 +40,7 @@ const createEnvironment = (
     governanceIndexerUrl:
       governanceIndexerUrl ||
       "https://lunar-services-worker.moonwell.workers.dev",
-    lunarIndexerUrl:
-      lunarIndexerUrl || "https://lunar-services-worker.moonwell.workers.dev",
+    lunarIndexerUrl: lunarIndexerUrl || DEFAULT_LUNAR_INDEXER_URL,
     tokens,
     markets,
     vaults: {},

--- a/src/environments/definitions/moonbeam/environment.ts
+++ b/src/environments/definitions/moonbeam/environment.ts
@@ -1,5 +1,6 @@
 import { http, fallback } from "viem";
 import { moonbeam } from "viem/chains";
+import { DEFAULT_LUNAR_INDEXER_URL } from "../../../common/lunar-indexer-helpers.js";
 import { createEnvironmentConfig } from "../../types/config.js";
 import { contracts } from "./contracts.js";
 import { markets } from "./core-markets.js";
@@ -23,8 +24,7 @@ const createEnvironment = (
     transport: rpcUrls
       ? fallback(rpcUrls.map((url) => http(url)))
       : http("https://rpc.moonwell.fi/main/evm/1284"),
-    lunarIndexerUrl:
-      lunarIndexerUrl || "https://lunar-services-worker.moonwell.workers.dev",
+    lunarIndexerUrl: lunarIndexerUrl || DEFAULT_LUNAR_INDEXER_URL,
     governanceIndexerUrl:
       governanceIndexerUrl ||
       "https://lunar-services-worker.moonwell.workers.dev",

--- a/src/environments/definitions/optimism/environment.ts
+++ b/src/environments/definitions/optimism/environment.ts
@@ -1,5 +1,6 @@
 import { http, defineChain, fallback } from "viem";
 import { optimism as optimismChain } from "viem/chains";
+import { DEFAULT_LUNAR_INDEXER_URL } from "../../../common/lunar-indexer-helpers.js";
 import { createEnvironmentConfig } from "../../types/config.js";
 import { contracts } from "./contracts.js";
 import { markets } from "./core-markets.js";
@@ -26,8 +27,7 @@ const createEnvironment = (
     transport: rpcUrls
       ? fallback(rpcUrls.map((url) => http(url)))
       : http("https://rpc.moonwell.fi/main/evm/10"),
-    lunarIndexerUrl:
-      lunarIndexerUrl || "https://lunar-services-worker.moonwell.workers.dev",
+    lunarIndexerUrl: lunarIndexerUrl || DEFAULT_LUNAR_INDEXER_URL,
     governanceIndexerUrl:
       governanceIndexerUrl ||
       "https://lunar-services-worker.moonwell.workers.dev",


### PR DESCRIPTION
## What & why

Merkl's v4 API needs a server-side API key for production rate limits. The SDK runs in the browser and **cannot hold a secret**, so it now calls the lunar-indexer worker's `/api/v1/merkl` proxy instead of `api.merkl.xyz` directly. The worker injects the key and forwards the query string + response unchanged.

This is the SDK follow-up to the indexer proxy ([lunar-indexer#69](https://github.com/moonwell-fi/lunar-indexer/pull/69), merged). Linear: [MOO-490](https://linear.app/moonwell/issue/MOO-490).

## Changes

- **`src/common/lunar-indexer-helpers.ts`** — new `getMerklProxyBaseUrl(lunarIndexerUrl?)` helper. Returns `${lunarIndexerUrl}/api/v1/merkl`, falling back to the production worker (`https://lunar-services-worker.moonwell.workers.dev`) when an environment has no `lunarIndexerUrl`, so Merkl data keeps resolving.
- **`src/actions/governance/common.ts`** — `getMerklCampaignIds`, `getMerklRewardsData`, and `getMerklStakingApr` now take an optional `lunarIndexerUrl` and build proxy URLs (was 4 of the 5 hardcoded `api.merkl.xyz` call sites).
- **callers** — `getUserStakingInfo` and `getStakingInfo` pass the base environment's `lunarIndexerUrl`.
- **`src/actions/morpho/user-rewards/common.ts`** — the 5th call site; builds the user-rewards URL from `environment.lunarIndexerUrl`.
- Changeset added (`patch`).

The two Merkl endpoints proxied:
| Was | Now |
| --- | --- |
| `GET api.merkl.xyz/v4/campaigns?...` | `GET {indexer}/api/v1/merkl/campaigns?...` |
| `GET api.merkl.xyz/v4/users/{account}/rewards?...` | `GET {indexer}/api/v1/merkl/users/{account}/rewards?...` |

## Public API

No changes. The modified governance functions are internal (not exported from `index.ts`); the only signature changes are a new optional trailing param. Request/response shapes are identical, so existing parsing/filtering is untouched.

## Tests

- Updated the two `MerklApiError.url` assertions in `morpho/user-rewards/common.test.ts` from `api.merkl.xyz` → `/api/v1/merkl/`.
- Added focused tests asserting each function calls the proxy URL (and honors a custom `lunarIndexerUrl`), and does **not** hit `api.merkl.xyz`.
- Full suite green (553 tests), `pnpm typecheck` and `pnpm lint` clean.

## Reviewer notes

The proxy is live and the `MERKL_API_KEY` secret must be set on the lunar-indexer worker for production calls (anonymous still works at a low rate limit). Consumers enforcing a network/CSP allowlist should permit the lunar-indexer host — already used for other SDK data.