### PR TITLE
feat(moonriver): route governor proposals through lunar-indexer Governor API (MOO-493)

### DIFF
--- a/.changeset/moo-493-moonriver-governor-lunar-indexer.md
+++ b/.changeset/moo-493-moonriver-governor-lunar-indexer.md
@@ -1,0 +1,7 @@
+---
+"@moonwell-fi/moonwell-sdk": patch
+---
+
+Route Moonriver (chainId 1285) governance through the lunar-indexer Governor API instead of Ponder (`ponder-eu2.moonwell.fi`).
+
+Moonriver proposals (`getProposals`/`getProposal`, via `fetchAllProposals`/`fetchProposal`) and vote receipts (`getUserVoteReceipt`, via `fetchUserVoteReceipt`) now come from the same lunar-indexer Governor API that already serves Moonbeam and Ethereum, using `chainId: 1285`. Moonriver runs a single legacy standalone governor (no multichain governor), so proposals are classified non-multichain and read state/quorum from the legacy governor exactly as the existing Moonbeam-historical path does. `SUPPORTED_GOVERNOR_CHAIN_IDS` now includes 1285 (additive). No public API changes — request/response shapes are identical, and Moonriver's lending `indexerUrl` is untouched. The old Ponder-based proposal fetchers have been removed.

--- a/src/actions/governance/getUserVoteReceipt.test.ts
+++ b/src/actions/governance/getUserVoteReceipt.test.ts
@@ -17,6 +17,7 @@ const mockedFetch = vi.mocked(fetchUserVoteReceipt);
 
 const ETHEREUM_CHAIN_ID = 1;
 const MOONBEAM_CHAIN_ID = 1284;
+const MOONRIVER_CHAIN_ID = 1285;
 const USER_ADDRESS = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd" as const;
 
 const moonbeamEnv = {
@@ -73,7 +74,8 @@ describe("getUserVoteReceipt", () => {
   test("returns receipts from chainId=1 when only that chain has votes", async () => {
     mockedFetch
       .mockResolvedValueOnce([makeReceipt(ETHEREUM_CHAIN_ID, "1000")])
-      .mockResolvedValueOnce([]); // chainId=1284 → proposal exists, user didn't vote
+      .mockResolvedValueOnce([]) // chainId=1284 → proposal exists, user didn't vote
+      .mockResolvedValueOnce([]); // chainId=1285 → Moonriver, user didn't vote
 
     const result = await getUserVoteReceipt(client, {
       network: "moonbeam",
@@ -84,16 +86,17 @@ describe("getUserVoteReceipt", () => {
     expect(result).toHaveLength(1);
     expect(result[0]?.voted).toBe(true);
     expect(result[0]?.chainId).toBe(ETHEREUM_CHAIN_ID);
-    expect(mockedFetch).toHaveBeenCalledTimes(2);
+    expect(mockedFetch).toHaveBeenCalledTimes(3);
   });
 
-  test("concatenates receipts from BOTH chains (proposalId collision case)", async () => {
-    // proposalId=7 happens to exist on both chains as different proposals; the
-    // same wallet voted on each. Caller should see both receipts, not just the
-    // first chain's.
+  test("concatenates receipts across chains (proposalId collision case)", async () => {
+    // proposalId=7 happens to exist on multiple chains as different proposals;
+    // the same wallet voted on each. Caller should see every receipt, not just
+    // the first chain's. Moonriver acknowledges but has no vote here.
     mockedFetch
       .mockResolvedValueOnce([makeReceipt(ETHEREUM_CHAIN_ID, "1000")])
-      .mockResolvedValueOnce([makeReceipt(MOONBEAM_CHAIN_ID, "500")]);
+      .mockResolvedValueOnce([makeReceipt(MOONBEAM_CHAIN_ID, "500")])
+      .mockResolvedValueOnce([]); // chainId=1285 → Moonriver, no vote
 
     const result = await getUserVoteReceipt(client, {
       network: "moonbeam",
@@ -108,7 +111,8 @@ describe("getUserVoteReceipt", () => {
   test("does not stop on a 200-empty response — would otherwise miss the other chain's vote", async () => {
     mockedFetch
       .mockResolvedValueOnce([]) // chainId=1: proposal exists, user didn't vote
-      .mockResolvedValueOnce([makeReceipt(MOONBEAM_CHAIN_ID, "750")]);
+      .mockResolvedValueOnce([makeReceipt(MOONBEAM_CHAIN_ID, "750")])
+      .mockResolvedValueOnce([]); // chainId=1285 → Moonriver, no vote
 
     const result = await getUserVoteReceipt(client, {
       network: "moonbeam",
@@ -120,8 +124,11 @@ describe("getUserVoteReceipt", () => {
     expect(result[0]?.chainId).toBe(MOONBEAM_CHAIN_ID);
   });
 
-  test("returns the empty-vote stub when both chains acknowledge but neither has receipts", async () => {
-    mockedFetch.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+  test("returns the empty-vote stub when all chains acknowledge but none have receipts", async () => {
+    mockedFetch
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]); // chainId=1285 → Moonriver acknowledges, no vote
 
     const result = await getUserVoteReceipt(client, {
       network: "moonbeam",
@@ -134,10 +141,11 @@ describe("getUserVoteReceipt", () => {
     expect(result[0]?.account).toBe(USER_ADDRESS);
   });
 
-  test("throws GovernorNotFoundError when both chains return 404 (proposal genuinely doesn't exist)", async () => {
+  test("throws GovernorNotFoundError when all chains return 404 (proposal genuinely doesn't exist)", async () => {
     mockedFetch
       .mockRejectedValueOnce(new GovernorNotFoundError(ETHEREUM_CHAIN_ID, 7))
-      .mockRejectedValueOnce(new GovernorNotFoundError(MOONBEAM_CHAIN_ID, 7));
+      .mockRejectedValueOnce(new GovernorNotFoundError(MOONBEAM_CHAIN_ID, 7))
+      .mockRejectedValueOnce(new GovernorNotFoundError(MOONRIVER_CHAIN_ID, 7));
 
     await expect(
       getUserVoteReceipt(client, {

--- a/src/actions/governance/getUserVoteReceipt.ts
+++ b/src/actions/governance/getUserVoteReceipt.ts
@@ -23,10 +23,10 @@ export type GetUserVoteReceiptParameters<
 
   /**
    * The chain the proposal lives on (1 = Ethereum multigov,
-   * 1284 = Moonbeam historical). When omitted, every supported chain is queried
-   * and non-empty receipts are concatenated — proposalIds may collide across
-   * chains (they represent different proposals), so a single bare proposalId
-   * can have votes on both Ethereum and Moonbeam.
+   * 1284 = Moonbeam historical, 1285 = Moonriver legacy). When omitted, every
+   * supported chain is queried and non-empty receipts are concatenated —
+   * proposalIds may collide across chains (they represent different proposals),
+   * so a single bare proposalId can have votes on more than one chain.
    */
   chainId?: number;
 };

--- a/src/actions/governance/governor-api-client.ts
+++ b/src/actions/governance/governor-api-client.ts
@@ -12,9 +12,10 @@ const getGovernorApiUrl = (environment: Environment): string => {
 
 /**
  * Chains the governor indexer serves. Ethereum first because that's where the
- * active multigov contract lives; Moonbeam follows for the historical archive.
+ * active multigov contract lives; Moonbeam follows for the historical archive,
+ * then Moonriver (legacy standalone governor).
  */
-export const SUPPORTED_GOVERNOR_CHAIN_IDS = [1, 1284] as const;
+export const SUPPORTED_GOVERNOR_CHAIN_IDS = [1, 1284, 1285] as const;
 
 /**
  * Build the chain-prefixed proposal key the indexer requires
@@ -168,8 +169,9 @@ export type FetchProposalsOptions = PaginationOptions & {
 /**
  * Fetch proposals from Governor API
  *
- * `chainId` is required by the indexer — 1 (Ethereum multigov) or
- * 1284 (Moonbeam historical). Missing/unsupported chainId returns 400.
+ * `chainId` is required by the indexer — 1 (Ethereum multigov),
+ * 1284 (Moonbeam historical), or 1285 (Moonriver legacy). Missing/unsupported
+ * chainId returns 400.
  */
 export async function fetchProposals(
   environment: Environment,

--- a/src/actions/governance/governor-api-client.ts
+++ b/src/actions/governance/governor-api-client.ts
@@ -14,8 +14,24 @@ const getGovernorApiUrl = (environment: Environment): string => {
  * Chains the governor indexer serves. Ethereum first because that's where the
  * active multigov contract lives; Moonbeam follows for the historical archive,
  * then Moonriver (legacy standalone governor).
+ *
+ * This is the fan-out set for `getUserVoteReceipt` — a bare proposalId is
+ * queried on every chain and non-empty receipts are concatenated. Do NOT use it
+ * as the single-proposal fallback in `getProposal`: Moonriver has its own
+ * explicit route there, and reaching a 1285 proposal through a Moonbeam env
+ * would surface a degraded result (see `MULTIGOV_PROPOSAL_FALLBACK_CHAIN_IDS`).
  */
 export const SUPPORTED_GOVERNOR_CHAIN_IDS = [1, 1284, 1285] as const;
+
+/**
+ * Fallback chains for a single multigov proposal lookup (`getProposal` with no
+ * explicit `chainId`), tried first-hit-wins. Deliberately excludes Moonriver
+ * (1285): Moonriver proposals are fetched through their own env via an explicit
+ * chainId, so a bare Moonbeam/Ethereum lookup must never resolve to a 1285
+ * proposal — that would return `quorum: 0n` (cross-chain quorum skips
+ * governor-less chains) and the wrong `environment`.
+ */
+export const MULTIGOV_PROPOSAL_FALLBACK_CHAIN_IDS = [1, 1284] as const;
 
 /**
  * Build the chain-prefixed proposal key the indexer requires

--- a/src/actions/governance/governor-api-client.ts
+++ b/src/actions/governance/governor-api-client.ts
@@ -104,6 +104,13 @@ export type ApiProposal = {
   targets: string[];
   values: string[];
   calldatas: string[];
+  /**
+   * Legacy/Artemis-governor function signatures (e.g. "setDirectPrice(address,uint256)"),
+   * parallel to `targets`/`calldatas`. Present for legacy-governor proposals
+   * (Moonriver, early Moonbeam) whose calldata carries no 4-byte selector;
+   * empty/absent for multichain-governor proposals (selector is in the calldata).
+   */
+  signatures?: string[];
   votingStartTime: number;
   votingEndTime: number;
   description: string;

--- a/src/actions/governance/ipfs.ts
+++ b/src/actions/governance/ipfs.ts
@@ -50,8 +50,8 @@ export const fetchIpfsContent = async (hash: string): Promise<string> => {
  * fetches run in parallel.
  *
  * Failures are logged via console.warn AND surfaced through
- * `env.onError` (matching the convention used by `getProposalData` /
- * `getExtendedProposalData`), then swallowed per-proposal: the `ipfs://` URI
+ * `env.onError` (matching the convention used by `getProposalsOnChainData` /
+ * `readCrossChainQuorums`), then swallowed per-proposal: the `ipfs://` URI
  * is left untouched so consumers can detect (e.g. via
  * `description.startsWith("ipfs://")`) and render a fallback. The bulk call
  * never rejects, so a single bad pin doesn't kill `getProposals()` for

--- a/src/actions/governance/proposals/common.test.ts
+++ b/src/actions/governance/proposals/common.test.ts
@@ -783,4 +783,32 @@ describe("getProposalsOnChainData local read failure", () => {
     expect(data?.state).toBe(ProposalState.Executed);
     expect(data?.proposalData).toBeNull();
   });
+
+  test("reports a swallowed quorum-read failure via onError with a distinct source", async () => {
+    // The quorum read runs once before the per-proposal loop, so an empty
+    // proposals array isolates it. On failure quorum silently stays 0n; the
+    // onError call is the only signal, and it uses a `governance-quorum` source
+    // distinct from the state/proposals reads for attributability.
+    const onError = vi.fn();
+    const env = {
+      chainId: 1285,
+      contracts: {
+        governor: {
+          read: {
+            getQuorum: vi.fn().mockRejectedValue(new Error("RPC down")),
+            proposalCount: vi.fn().mockResolvedValue(0n),
+          },
+        },
+      },
+      custom: {},
+      onError,
+    } as unknown as Parameters<typeof getProposalsOnChainData>[1];
+
+    await getProposalsOnChainData([], env);
+
+    expect(onError).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ source: "governance-quorum", chainId: 1285 }),
+    );
+  });
 });

--- a/src/actions/governance/proposals/common.test.ts
+++ b/src/actions/governance/proposals/common.test.ts
@@ -226,6 +226,33 @@ describe("classifyProposalMultichain", () => {
       ),
     ).toBe(true);
   });
+
+  test("cutoff read failure (undefined) does NOT bias to multichain on a legacy-only chain (Moonriver)", () => {
+    // MOO-493: Moonriver has a legacy governor but no multichainGovernor, so the
+    // proposal-171 unknown-cutoff bias must not apply — biasing to multichain
+    // would route reads to a nonexistent multichain governor and surface a
+    // spurious `multichain` field. With hasMultichainGovernor=false it stays
+    // non-multichain and reads from the legacy governor.
+    expect(
+      classifyProposalMultichain(
+        { targets: [LOCAL_TARGET], proposalId: 999, chainId: 1285 },
+        undefined,
+        false,
+      ),
+    ).toBe(false);
+  });
+
+  test("cutoff read failure (undefined) still biases to multichain when the chain has a multichain governor", () => {
+    // Explicit hasMultichainGovernor=true keeps the dual-governor (Moonbeam)
+    // bias intact even when passed explicitly.
+    expect(
+      classifyProposalMultichain(
+        { targets: [LOCAL_TARGET], proposalId: 999, chainId: 1284 },
+        undefined,
+        true,
+      ),
+    ).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/actions/governance/proposals/common.ts
+++ b/src/actions/governance/proposals/common.ts
@@ -1,16 +1,12 @@
 import axios from "axios";
-import last from "lodash/last.js";
-import { moonriver } from "viem/chains";
 import { Amount } from "../../../common/index.js";
 import type { Environment } from "../../../environments/index.js";
 import { publicEnvironments } from "../../../environments/index.js";
 import {
   MultichainProposalState,
   MultichainProposalStateMapping,
-  type Proposal,
   ProposalState,
 } from "../../../types/proposal.js";
-import { postWithRetry } from "../../axiosWithRetry.js";
 import type { ApiProposal } from "../governor-api-client.js";
 
 export const WORMHOLE_CONTRACT = "0xc8e2b0cd52cf01b0ce87d389daa3d414d4ce29f3"; // Moonbeam
@@ -24,21 +20,6 @@ const MULTICHAIN_WORMHOLE_BRIDGES: ReadonlySet<string> = new Set([
   WORMHOLE_CONTRACT,
   "0x98f3c9e6e3face36baad05fe09d375ef1464288b", // Ethereum
 ]);
-
-type PonderExtendedProposalData = {
-  id: number;
-  title: string;
-  subtitle: string;
-  description: string;
-  targets: string[];
-  calldatas: string[];
-  signatures: string[];
-  stateChanges: {
-    blockNumber: number;
-    transactionHash: string;
-    state: string;
-  }[];
-};
 
 axios.defaults.timeout = 5_000;
 
@@ -143,15 +124,26 @@ export const isMultichainHomeChain = (chainId: number): boolean => {
  * falls back to the home/bridge checks. Omit it or pass `undefined` when the
  * count read failed so the unknown-cutoff bias above applies. (No `= 0` default:
  * that would coerce an explicit `undefined` back to 0 and defeat the bias.)
+ *
+ * `hasMultichainGovernor` gates rule 4: the unknown-cutoff bias only makes sense
+ * on a chain that actually has a multichain governor to route to. On a
+ * legacy-only chain (Moonriver — legacy `governor`, no `multichainGovernor`) a
+ * failed Artemis count must NOT flip the proposal to multichain, which would
+ * route reads to a null contract and surface a spurious `multichain` field.
+ * Defaults to `true` so callers that don't supply it keep the dual-governor
+ * (Moonbeam) bias behavior.
  */
 export const classifyProposalMultichain = (
   proposal: { targets?: string[]; proposalId: number; chainId: number },
   legacyArtemisMaxId?: number,
+  hasMultichainGovernor = true,
 ): boolean =>
   isMultichainHomeChain(proposal.chainId) ||
   isMultichainProposal(proposal.targets) ||
-  legacyArtemisMaxId === undefined ||
-  (legacyArtemisMaxId > 0 && proposal.proposalId > legacyArtemisMaxId);
+  (legacyArtemisMaxId === undefined && hasMultichainGovernor) ||
+  (legacyArtemisMaxId !== undefined &&
+    legacyArtemisMaxId > 0 &&
+    proposal.proposalId > legacyArtemisMaxId);
 
 /**
  * @deprecated Use `classifyProposalMultichain` — this variant misses hub-homed
@@ -330,9 +322,8 @@ const getLegacyArtemisMaxId = async (
  * the `options.crossChainQuorums?.get(...) ?? 0n` pattern.
  *
  * Read failures are routed through `onError` so Sentry-wired consumers see
- * them — matching `getProposalData` / `getCrossChainProposalData` /
- * `getExtendedProposalData`. The caller's `governanceEnvironment` carries
- * `onError` since we don't have one per foreign chain in scope.
+ * them — matching `getProposalsOnChainData`. The caller's `governanceEnvironment`
+ * carries `onError` since we don't have one per foreign chain in scope.
  */
 export const getEnvironmentByChainId = (
   chainId: number,
@@ -393,6 +384,13 @@ export const getProposalsOnChainData = async (
           : await governanceEnvironment.contracts.governor.read.getQuorum();
     } catch (error) {
       console.warn("Failed to fetch quorum:", error);
+      // Report like the state/proposals reads below so a swallowed quorum
+      // failure (which leaves quorum at 0n) is still observable to onError-wired
+      // consumers — the legacy Moonriver path surfaced this too.
+      governanceEnvironment.onError?.(error, {
+        source: "governance-proposals",
+        chainId: governanceEnvironment.chainId,
+      });
     }
   }
 
@@ -420,10 +418,13 @@ export const getProposalsOnChainData = async (
       // (Ethereum multigov, no Artemis predecessor) classify as multichain
       // regardless of targets via classifyProposalMultichain. Computed once
       // here and returned on ProposalOnChainData so callers don't re-classify
-      // and drift (see getProposal/getProposals).
+      // and drift (see getProposal/getProposals). `hasMultichainGovernor` keeps
+      // the unknown-cutoff bias from misrouting legacy-only chains (Moonriver)
+      // to a nonexistent multichain governor when the Artemis count read fails.
       const isMultichain = classifyProposalMultichain(
         p,
         isLocal ? legacyArtemisMaxId : 0,
+        Boolean(homeEnv?.contracts.multichainGovernor),
       );
 
       if (!homeEnv) {
@@ -556,445 +557,4 @@ export const getProposalsOnChainData = async (
   );
 
   return onChainDataList;
-};
-
-/**
- * Get proposal data from on-chain (Ponder-based, for Moonriver)
- */
-export const getProposalData = async (params: {
-  environment: Environment;
-  id?: number;
-}) => {
-  try {
-    if (params.environment.contracts.governor) {
-      let count = 0n;
-      let quorum = 0n;
-
-      if (params.environment.chainId === moonriver.id) {
-        [count, quorum] = await Promise.all([
-          params.environment.contracts.governor.read.proposalCount(),
-          params.environment.contracts.governor.read.getQuorum(),
-        ]);
-      } else {
-        [count, quorum] = await Promise.all([
-          params.environment.contracts.governor.read.proposalCount(),
-          params.environment.contracts.governor.read.quorumVotes(),
-        ]);
-      }
-
-      if (params.id) {
-        if (BigInt(params.id) > count) {
-          return [];
-        }
-      }
-
-      const ids = params.id
-        ? [BigInt(params.id)]
-        : Array.from({ length: Number(count) }, (_, i) => count - BigInt(i));
-
-      const proposalDataCall = Promise.all(
-        ids.map((id) =>
-          params.environment.contracts.governor?.read.proposals([id]),
-        ),
-      );
-
-      const proposalStateCall = Promise.all(
-        ids.map((id) =>
-          params.environment.contracts.governor?.read.state([id]),
-        ),
-      );
-
-      const [proposalsData, proposalsState] = await Promise.all([
-        proposalDataCall,
-        proposalStateCall,
-      ]);
-
-      const proposals = proposalsData?.map((item, index: number) => {
-        const state = proposalsState?.[index]!;
-
-        const [
-          id,
-          proposer,
-          eta,
-          startTimestamp,
-          endTimestamp,
-          startBlock,
-          forVotes,
-          againstVotes,
-          abstainVotes,
-          totalVotes,
-          canceled,
-          executed,
-        ] = item!;
-
-        const proposal: Proposal = {
-          chainId: params.environment.chainId,
-          id: Number(id),
-          proposalId: Number(id),
-          proposer,
-          eta: Number(eta),
-          startTimestamp: Number(startTimestamp),
-          endTimestamp: Number(endTimestamp),
-          startBlock: Number(startBlock),
-          forVotes: new Amount(forVotes, 18),
-          againstVotes: new Amount(againstVotes, 18),
-          abstainVotes: new Amount(abstainVotes, 18),
-          totalVotes: new Amount(totalVotes, 18),
-          canceled,
-          executed,
-          quorum: new Amount(quorum, 18),
-          state,
-        };
-
-        return proposal;
-      });
-
-      return proposals;
-    } else {
-      return [];
-    }
-  } catch (error) {
-    console.warn(
-      `[getProposalData] RPC failed for chain ${params.environment.chainId}:`,
-      error,
-    );
-    params.environment.onError?.(error, {
-      source: "governance-proposals",
-      chainId: params.environment.chainId,
-    });
-    return [];
-  }
-};
-
-/**
- * Get cross-chain proposal data (Ponder-based, for Moonriver)
- */
-export const getCrossChainProposalData = async (params: {
-  environment: Environment;
-  id?: number;
-}) => {
-  try {
-    if (params.environment.contracts.governor) {
-      const xcGovernanceSettings = params.environment.custom.governance;
-      if (
-        params.environment.contracts.multichainGovernor &&
-        xcGovernanceSettings &&
-        xcGovernanceSettings.chainIds.length > 0
-      ) {
-        const xcEnvironments = xcGovernanceSettings.chainIds
-          .map((chainId) =>
-            (Object.values(publicEnvironments) as Environment[]).find(
-              (env) => env.chainId === chainId,
-            ),
-          )
-          .filter((xcEnvironment) => !!xcEnvironment)
-          .filter(
-            (xcEnvironment) =>
-              xcEnvironment!.custom?.wormhole?.chainId &&
-              xcEnvironment!.contracts.voteCollector,
-          );
-
-        const [xcCount, xcQuorum] = await Promise.all([
-          params.environment.contracts.multichainGovernor.read.proposalCount(),
-          params.environment.contracts.multichainGovernor.read.quorum(),
-        ]);
-
-        if (params.id) {
-          params.id =
-            Number(params.id) -
-            (params.environment.custom?.governance?.proposalIdOffset || 0);
-
-          if (params.id < 0) return [];
-          if (BigInt(params.id) > xcCount) return [];
-        }
-
-        const ids = params.id
-          ? [BigInt(params.id)]
-          : Array.from(
-              { length: Number(xcCount) },
-              (_, i) => xcCount - BigInt(i),
-            );
-
-        const xcProposalsDataCall = Promise.all(
-          ids.map((id) =>
-            params.environment.contracts.multichainGovernor?.read.proposals([
-              id,
-            ]),
-          ),
-        );
-
-        const xcProposalsStateCall = Promise.all(
-          ids.map((id) =>
-            params.environment.contracts.multichainGovernor?.read.state([id]),
-          ),
-        );
-
-        const xcVotesCall = Promise.all(
-          xcEnvironments.map((xcEnvironment) =>
-            Promise.all(
-              ids.map((id) =>
-                params.environment.contracts.multichainGovernor?.read.chainVoteCollectorVotes(
-                  [(xcEnvironment!.custom as any).wormhole.chainId, id],
-                ),
-              ),
-            ),
-          ),
-        );
-
-        const [xcProposalsData, xcProposalsState, xcVotes] = await Promise.all([
-          xcProposalsDataCall,
-          xcProposalsStateCall,
-          xcVotesCall,
-        ]);
-
-        const proposals = ids.map((xcId, proposalIndex: number) => {
-          const state = xcProposalsState?.[proposalIndex]!;
-          const id =
-            Number(xcId) +
-            (params.environment.custom?.governance?.proposalIdOffset || 0);
-
-          const votesCollected = false;
-
-          const votes = xcVotes.reduce(
-            (prevVotes, currVotes) => {
-              const voteData = currVotes[proposalIndex];
-              if (!voteData) {
-                return prevVotes;
-              }
-
-              // chainVoteCollectorVotes returns [forVotes, againstVotes, abstainVotes]
-              const forVotes = voteData[0] || 0n;
-              const againstVotes = voteData[1] || 0n;
-              const abstainVotes = voteData[2] || 0n;
-              const totalVotes = forVotes + againstVotes + abstainVotes;
-
-              return {
-                totalVotes: prevVotes.totalVotes + totalVotes,
-                forVotes: prevVotes.forVotes + forVotes,
-                againstVotes: prevVotes.againstVotes + againstVotes,
-                abstainVotes: prevVotes.abstainVotes + abstainVotes,
-              };
-            },
-            {
-              totalVotes: 0n,
-              forVotes: 0n,
-              againstVotes: 0n,
-              abstainVotes: 0n,
-            },
-          );
-
-          const proposalData = xcProposalsData?.[proposalIndex];
-          if (!proposalData) {
-            throw new Error(
-              `Proposal data not found for index ${proposalIndex}`,
-            );
-          }
-
-          const [
-            proposer,
-            _voteSnapshotTimestamp,
-            votingStartTime,
-            votingEndTime,
-            crossChainVoteCollectionEndTimestamp,
-            voteSnapshotBlock,
-            proposalForVotes,
-            proposalAgainstVotes,
-            proposalAbstainVotes,
-            proposalTotalVotes,
-            canceled,
-            executed,
-          ] = proposalData;
-
-          const multichainState = (
-            MultichainProposalStateMapping as { [key: number]: ProposalState }
-          )[state]!;
-
-          const proposal: Proposal = {
-            chainId: params.environment.chainId,
-            id,
-            proposalId: Number(xcId),
-            proposer,
-            eta: Number(crossChainVoteCollectionEndTimestamp),
-            startTimestamp: Number(votingStartTime),
-            endTimestamp: Number(votingEndTime),
-            startBlock: Number(voteSnapshotBlock),
-            forVotes: new Amount(proposalForVotes + votes.forVotes, 18),
-            againstVotes: new Amount(
-              proposalAgainstVotes + votes.againstVotes,
-              18,
-            ),
-            abstainVotes: new Amount(
-              proposalAbstainVotes + votes.abstainVotes,
-              18,
-            ),
-            totalVotes: new Amount(proposalTotalVotes + votes.totalVotes, 18),
-            canceled,
-            executed,
-            quorum: new Amount(xcQuorum, 18),
-            state: multichainState,
-            multichain: {
-              id: Number(xcId),
-              votesCollected,
-            },
-          };
-
-          return proposal;
-        });
-
-        return proposals;
-      } else {
-        return [];
-      }
-    } else {
-      return [];
-    }
-  } catch (error) {
-    console.warn(
-      `[getCrossChainProposalData] RPC failed for chain ${params.environment.chainId}:`,
-      error,
-    );
-    params.environment.onError?.(error, {
-      source: "governance-proposals",
-      chainId: params.environment.chainId,
-    });
-    return [];
-  }
-};
-
-export const appendProposalExtendedData = (
-  proposals: Proposal[],
-  extendedDatas: PonderExtendedProposalData[],
-) => {
-  proposals.forEach((proposal) => {
-    const extendedData = extendedDatas.find(
-      (item) => item.id === proposal.proposalId,
-    );
-
-    if (extendedData) {
-      proposal.title = extendedData.title;
-      proposal.calldatas = extendedData.calldatas;
-      proposal.description = extendedData.description;
-      proposal.signatures = extendedData.signatures;
-      proposal.stateChanges = extendedData.stateChanges.map((change) => ({
-        blockNumber: change.blockNumber,
-        transactionHash: change.transactionHash,
-        state: change.state,
-        chainId: proposal.chainId,
-      }));
-      proposal.subtitle = extendedData.subtitle;
-      proposal.targets = extendedData.targets;
-    }
-  });
-};
-
-export const getExtendedProposalData = async (params: {
-  environment: Environment;
-  id?: number;
-}): Promise<PonderExtendedProposalData[]> => {
-  const result: PonderExtendedProposalData[] = [];
-  let lastId = -1;
-  let shouldContinue = true;
-  const MAX_PAGES = 100;
-  let page = 0;
-
-  try {
-    while (shouldContinue && page < MAX_PAGES) {
-      page++;
-      const response = await postWithRetry<{
-        data: {
-          proposals: {
-            items: {
-              proposalId: number;
-              description: string;
-              targets: string[];
-              calldatas: string[];
-              signatures: string[];
-              stateChanges: {
-                items: {
-                  txnHash: string;
-                  blockNumber: number;
-                  newState: string;
-                }[];
-              };
-            }[];
-          };
-        };
-      }>("https://ponder-eu2.moonwell.fi", {
-        query: `
-            query {
-              proposals(
-                limit: 1000,
-                orderDirection: "desc",
-                orderBy: "proposalId",
-                where: {
-                  chainId: ${params.environment.chainId}
-                  ${params.id ? `, proposalId: ${params.id}` : lastId >= 0 ? `, proposalId_lt: ${lastId}` : ""}
-                }
-              ) {
-                items {
-                  id
-                  proposalId
-                  description
-                  targets
-                  calldatas
-                  signatures
-                  stateChanges(orderBy: "blockNumber") {
-                    items {
-                      txnHash
-                      blockNumber
-                      newState
-                    }
-                  }
-                }
-              }
-            }
-          `,
-      });
-
-      if (response.status === 200 && response.data?.data?.proposals) {
-        const proposals = response.data.data.proposals.items.map((item) => {
-          const extendedProposalData: PonderExtendedProposalData = {
-            id: item.proposalId,
-            title: `Proposal #${item.proposalId}`,
-            subtitle: extractProposalSubtitle(item.description),
-            description: item.description,
-            calldatas: item.calldatas,
-            signatures: item.signatures,
-            stateChanges: item.stateChanges.items.map((change) => {
-              return {
-                blockNumber: change.blockNumber,
-                state: change.newState,
-                transactionHash: change.txnHash,
-              };
-            }),
-            targets: item.targets,
-          };
-
-          return extendedProposalData;
-        });
-
-        if (proposals.length < 1000 || proposals.length === 0) {
-          shouldContinue = false;
-        } else {
-          lastId = last(proposals)!.id;
-        }
-
-        result.push(...proposals);
-      } else {
-        shouldContinue = false;
-      }
-    }
-  } catch (error) {
-    console.warn(
-      `[getExtendedProposalData] Ponder failed for chain ${params.environment.chainId}:`,
-      error,
-    );
-    params.environment.onError?.(error, {
-      source: "governance-proposals",
-      chainId: params.environment.chainId,
-    });
-    return result;
-  }
-
-  return result;
 };

--- a/src/actions/governance/proposals/common.ts
+++ b/src/actions/governance/proposals/common.ts
@@ -384,11 +384,13 @@ export const getProposalsOnChainData = async (
           : await governanceEnvironment.contracts.governor.read.getQuorum();
     } catch (error) {
       console.warn("Failed to fetch quorum:", error);
-      // Report like the state/proposals reads below so a swallowed quorum
-      // failure (which leaves quorum at 0n) is still observable to onError-wired
-      // consumers — the legacy Moonriver path surfaced this too.
+      // Report so a swallowed quorum failure (which leaves quorum at 0n) is
+      // still observable to onError-wired consumers — the legacy Moonriver path
+      // surfaced this too. Uses a distinct `source` from the state/proposals
+      // reads (and from readCrossChainQuorums' "governance-cross-chain-quorum")
+      // so a local quorum-read failure is attributable on its own.
       governanceEnvironment.onError?.(error, {
-        source: "governance-proposals",
+        source: "governance-quorum",
         chainId: governanceEnvironment.chainId,
       });
     }

--- a/src/actions/governance/proposals/getProposal.test.ts
+++ b/src/actions/governance/proposals/getProposal.test.ts
@@ -121,6 +121,9 @@ describe("getProposal state post-processing", () => {
     } as unknown as Parameters<typeof getProposal>[1]);
 
     expect(result?.state).toBe(1); // ProposalState.Active
+    // Empty-fallback: the API omits `signatures` for multichain proposals
+    // (selector is in the calldata), so `apiProposal.signatures ?? []` yields [].
+    expect(result?.signatures).toEqual([]);
     // Regression guard against #3: the third argument carrying
     // `crossChainQuorums` must reach getProposalsOnChainData. A wiring
     // regression that drops it would still make assertions on `state` pass.
@@ -316,11 +319,10 @@ describe("getProposal fallback behavior", () => {
     expect(mockedFetchProposal.mock.calls[1]?.[1]).toBe(MOONBEAM_CHAIN_ID);
   });
 
-  test("returns undefined when all supported chains return NotFoundError", async () => {
+  test("returns undefined when the multigov chains (1, 1284) return NotFoundError", async () => {
     mockedFetchProposal
       .mockRejectedValueOnce(new GovernorNotFoundError(ETHEREUM_CHAIN_ID, 7))
-      .mockRejectedValueOnce(new GovernorNotFoundError(MOONBEAM_CHAIN_ID, 7))
-      .mockRejectedValueOnce(new GovernorNotFoundError(1285, 7));
+      .mockRejectedValueOnce(new GovernorNotFoundError(MOONBEAM_CHAIN_ID, 7));
 
     const result = await getProposal(client, {
       network: "moonbeam",
@@ -328,8 +330,42 @@ describe("getProposal fallback behavior", () => {
     } as unknown as Parameters<typeof getProposal>[1]);
 
     expect(result).toBeUndefined();
-    expect(mockedFetchProposal).toHaveBeenCalledTimes(3);
+    // Only the two multigov chains are tried — Moonriver (1285) is NOT in the
+    // fallback, so the loop stops at 1284.
+    expect(mockedFetchProposal).toHaveBeenCalledTimes(2);
     expect(mockedOnChain).not.toHaveBeenCalled();
+  });
+
+  test("bare Moonbeam lookup does NOT fall through to a Moonriver (1285) proposal", async () => {
+    // Regression for the review Major: 1285 must not be in the multigov fallback.
+    // A bare id that 404s on Ethereum and Moonbeam but exists on Moonriver must
+    // return undefined (not the 1285 proposal, which would carry quorum: 0n and
+    // the wrong environment when reached via the Moonbeam env). The
+    // chainId-keyed implementation would surface a 1285 proposal if the fallback
+    // ever regressed to include it — so the test fails loudly on regression.
+    mockedFetchProposal.mockImplementation(async (_env, cid) => {
+      if (cid === 1285) {
+        return { ...baseApiProposal, chainId: 1285, proposalId: 7 };
+      }
+      throw new GovernorNotFoundError(cid, 7);
+    });
+
+    const result = await getProposal(client, {
+      network: "moonbeam",
+      proposalId: 7,
+    } as unknown as Parameters<typeof getProposal>[1]);
+
+    expect(result).toBeUndefined();
+    expect(mockedFetchProposal).toHaveBeenCalledTimes(2);
+    expect(mockedFetchProposal).not.toHaveBeenCalledWith(
+      expect.anything(),
+      1285,
+      expect.anything(),
+    );
+
+    // clearAllMocks (this file's afterEach) doesn't drop implementations; reset
+    // so the persistent impl doesn't leak into later tests' once-queues.
+    mockedFetchProposal.mockReset();
   });
 
   test("re-throws non-404 errors without trying the next chain (indexer outage)", async () => {

--- a/src/actions/governance/proposals/getProposal.test.ts
+++ b/src/actions/governance/proposals/getProposal.test.ts
@@ -433,6 +433,12 @@ describe("getProposal Moonriver via Governor API (MOO-493)", () => {
       chainId: 1285,
       proposalId: 74,
       description: "# MIP-R10: Test\nbody",
+      // Legacy-governor signatures (selector lives here, not in the calldata) —
+      // the mapper must pass them through for the frontend to decode the call.
+      signatures: [
+        "setDirectPrice(address,uint256)",
+        "setFeed(string,address)",
+      ],
     });
     mockedOnChain.mockResolvedValueOnce([
       { ...defaultOnChain, state: ProposalState.Succeeded, quorum: 123n },
@@ -446,6 +452,10 @@ describe("getProposal Moonriver via Governor API (MOO-493)", () => {
     expect(result?.id).toBe(74);
     expect(result?.state).toBe(ProposalState.Succeeded);
     expect(result?.quorum.exponential).toBe(123n);
+    expect(result?.signatures).toEqual([
+      "setDirectPrice(address,uint256)",
+      "setFeed(string,address)",
+    ]);
     // No multichain governor on Moonriver → the field must be absent.
     expect(result?.multichain).toBeUndefined();
     expect(result?.environment).toBe(moonriverEnv);

--- a/src/actions/governance/proposals/getProposal.test.ts
+++ b/src/actions/governance/proposals/getProposal.test.ts
@@ -316,10 +316,11 @@ describe("getProposal fallback behavior", () => {
     expect(mockedFetchProposal.mock.calls[1]?.[1]).toBe(MOONBEAM_CHAIN_ID);
   });
 
-  test("returns undefined when both chains return NotFoundError", async () => {
+  test("returns undefined when all supported chains return NotFoundError", async () => {
     mockedFetchProposal
       .mockRejectedValueOnce(new GovernorNotFoundError(ETHEREUM_CHAIN_ID, 7))
-      .mockRejectedValueOnce(new GovernorNotFoundError(MOONBEAM_CHAIN_ID, 7));
+      .mockRejectedValueOnce(new GovernorNotFoundError(MOONBEAM_CHAIN_ID, 7))
+      .mockRejectedValueOnce(new GovernorNotFoundError(1285, 7));
 
     const result = await getProposal(client, {
       network: "moonbeam",
@@ -327,7 +328,7 @@ describe("getProposal fallback behavior", () => {
     } as unknown as Parameters<typeof getProposal>[1]);
 
     expect(result).toBeUndefined();
-    expect(mockedFetchProposal).toHaveBeenCalledTimes(2);
+    expect(mockedFetchProposal).toHaveBeenCalledTimes(3);
     expect(mockedOnChain).not.toHaveBeenCalled();
   });
 
@@ -389,6 +390,65 @@ describe("getProposal fallback behavior", () => {
 
     expect(result).toBeUndefined();
     expect(mockedFetchProposal).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Moonriver routing branch (MOO-493) — single legacy governor, served by the
+// same lunar indexer Governor API, never multichain.
+// ---------------------------------------------------------------------------
+
+describe("getProposal Moonriver via Governor API (MOO-493)", () => {
+  test("routes through fetchProposal with chainId 1285 and no fallback (no Ponder)", async () => {
+    mockedFetchProposal.mockResolvedValueOnce({
+      ...baseApiProposal,
+      id: "1285-0000000074",
+      chainId: 1285,
+      proposalId: 74,
+    });
+    mockedOnChain.mockResolvedValueOnce([defaultOnChain]);
+
+    const result = await getProposal(client, {
+      network: "moonriver",
+      proposalId: 74,
+    } as unknown as Parameters<typeof getProposal>[1]);
+
+    expect(result?.chainId).toBe(1285);
+    expect(result?.proposalId).toBe(74);
+    // Exactly one call, pinned to chainId 1285 — Moonriver is never tried
+    // against the Ethereum/Moonbeam chains, and the old Ponder path is gone.
+    expect(mockedFetchProposal).toHaveBeenCalledTimes(1);
+    expect(mockedFetchProposal).toHaveBeenCalledWith(moonriverEnv, 1285, 74);
+    expect(mockedOnChain).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.anything(),
+      expect.objectContaining({ crossChainQuorums: expect.any(Map) }),
+    );
+  });
+
+  test("maps a non-multichain Moonriver proposal to the legacy Proposal shape", async () => {
+    mockedFetchProposal.mockResolvedValueOnce({
+      ...baseApiProposal,
+      id: "1285-0000000074",
+      chainId: 1285,
+      proposalId: 74,
+      description: "# MIP-R10: Test\nbody",
+    });
+    mockedOnChain.mockResolvedValueOnce([
+      { ...defaultOnChain, state: ProposalState.Succeeded, quorum: 123n },
+    ]);
+
+    const result = await getProposal(client, {
+      network: "moonriver",
+      proposalId: 74,
+    } as unknown as Parameters<typeof getProposal>[1]);
+
+    expect(result?.id).toBe(74);
+    expect(result?.state).toBe(ProposalState.Succeeded);
+    expect(result?.quorum.exponential).toBe(123n);
+    // No multichain governor on Moonriver → the field must be absent.
+    expect(result?.multichain).toBeUndefined();
+    expect(result?.environment).toBe(moonriverEnv);
   });
 });
 

--- a/src/actions/governance/proposals/getProposal.ts
+++ b/src/actions/governance/proposals/getProposal.ts
@@ -178,7 +178,10 @@ async function getGovernorApiProposal(
     description: apiProposal.description,
     targets: apiProposal.targets,
     calldatas: apiProposal.calldatas,
-    signatures: [],
+    // Legacy-governor proposals (Moonriver, early Moonbeam) carry the function
+    // signature separately from the selector-less calldata; pass it through so
+    // consumers can decode the call. Empty for multichain-governor proposals.
+    signatures: apiProposal.signatures ?? [],
     stateChanges: formattedData.stateChanges,
     environment: governanceEnvironment,
   };

--- a/src/actions/governance/proposals/getProposal.ts
+++ b/src/actions/governance/proposals/getProposal.ts
@@ -6,7 +6,7 @@ import type { Chain, Environment } from "../../../environments/index.js";
 import { type Proposal, ProposalState } from "../../../types/proposal.js";
 import {
   type ApiProposal,
-  SUPPORTED_GOVERNOR_CHAIN_IDS,
+  MULTIGOV_PROPOSAL_FALLBACK_CHAIN_IDS,
   fetchProposal,
   isNotFoundError,
 } from "../governor-api-client.js";
@@ -84,16 +84,19 @@ export async function getProposal<
  * Moonriver legacy governor).
  *
  * When `chainId` is provided we hit only that chain. When omitted we try the
- * supported chains in order (Ethereum first since that's where active multigov
- * proposals live) and fall back on `NotFoundError`. Real outages (5xx, network
- * errors) propagate so callers can distinguish "missing" from "broken".
+ * multigov chains in order (Ethereum first since that's where active multigov
+ * proposals live) and fall back on `NotFoundError`. Moonriver (1285) is
+ * deliberately absent from the fallback — it has its own explicit route, and a
+ * bare lookup resolving to it through a non-Moonriver env would be degraded.
+ * Real outages (5xx, network errors) propagate so callers can distinguish
+ * "missing" from "broken".
  */
 async function getGovernorApiProposal(
   governanceEnvironment: Environment,
   proposalId: number,
   chainId?: number,
 ): Promise<Proposal | undefined> {
-  const tryChains = chainId ? [chainId] : SUPPORTED_GOVERNOR_CHAIN_IDS;
+  const tryChains = chainId ? [chainId] : MULTIGOV_PROPOSAL_FALLBACK_CHAIN_IDS;
 
   let apiProposal: ApiProposal | undefined;
   for (const cid of tryChains) {

--- a/src/actions/governance/proposals/getProposal.ts
+++ b/src/actions/governance/proposals/getProposal.ts
@@ -12,11 +12,7 @@ import {
 } from "../governor-api-client.js";
 import { resolveIpfsDescriptions } from "../ipfs.js";
 import {
-  appendProposalExtendedData,
   formatApiProposalData,
-  getCrossChainProposalData,
-  getExtendedProposalData,
-  getProposalData,
   getProposalsOnChainData,
   readCrossChainQuorums,
 } from "./common.js";
@@ -28,7 +24,8 @@ export type GetProposalParameters<
   proposalId: number;
   /**
    * The chain the proposal lives on (1 = Ethereum multigov,
-   * 1284 = Moonbeam historical). When omitted, both are tried in turn.
+   * 1284 = Moonbeam historical, 1285 = Moonriver legacy). When omitted, the
+   * supported chains are tried in turn.
    */
   chainId?: number;
 };
@@ -51,7 +48,7 @@ export async function getProposal<
 
   // Ethereum-home multigov proposals are served by the same Governor API as
   // historical Moonbeam ones (the lunar indexer fans out both chainIds), so
-  // route them through `getMoonbeamProposal` using the Moonbeam env as the
+  // route them through `getGovernorApiProposal` using the Moonbeam env as the
   // indexer source. Without this, a caller resolving the env by `chainId: 1`
   // would bail out on the `!moonbeam && !moonriver` check below and the page
   // reload path returns undefined.
@@ -62,7 +59,7 @@ export async function getProposal<
     if (!moonbeamEnv) {
       return undefined;
     }
-    return getMoonbeamProposal(
+    return getGovernorApiProposal(
       moonbeamEnv,
       proposalId,
       args.chainId ?? mainnet.id,
@@ -77,20 +74,21 @@ export async function getProposal<
   }
 
   if (environment.chainId === moonbeam.id) {
-    return getMoonbeamProposal(environment, proposalId, args.chainId);
+    return getGovernorApiProposal(environment, proposalId, args.chainId);
   }
-  return getMoonriverProposal(environment, proposalId);
+  return getGovernorApiProposal(environment, proposalId, moonriver.id);
 }
 
 /**
- * Fetch a single proposal for Moonbeam using the Governor API.
+ * Fetch a single proposal from the Governor API (Moonbeam/Ethereum multigov or
+ * Moonriver legacy governor).
  *
  * When `chainId` is provided we hit only that chain. When omitted we try the
  * supported chains in order (Ethereum first since that's where active multigov
  * proposals live) and fall back on `NotFoundError`. Real outages (5xx, network
  * errors) propagate so callers can distinguish "missing" from "broken".
  */
-async function getMoonbeamProposal(
+async function getGovernorApiProposal(
   governanceEnvironment: Environment,
   proposalId: number,
   chainId?: number,
@@ -193,36 +191,4 @@ async function getMoonbeamProposal(
   }
 
   return proposal;
-}
-
-/**
- * Fetch a single proposal for Moonriver using the old Ponder-based approach
- */
-async function getMoonriverProposal(
-  governanceEnvironment: Environment,
-  proposalId: number,
-): Promise<Proposal | undefined> {
-  const [_proposals, _xcProposals, _extendedDatas] = await Promise.all([
-    getProposalData({ environment: governanceEnvironment, id: proposalId }),
-    getCrossChainProposalData({
-      environment: governanceEnvironment,
-      id: proposalId,
-    }),
-    getExtendedProposalData({
-      environment: governanceEnvironment,
-      id: proposalId,
-    }),
-  ]);
-
-  const proposals = [..._proposals, ..._xcProposals];
-
-  proposals.forEach((proposal) => {
-    proposal.environment = governanceEnvironment;
-  });
-
-  appendProposalExtendedData(proposals, _extendedDatas);
-
-  return proposals.find(
-    (p) => p.proposalId === proposalId || p.id === proposalId,
-  );
 }

--- a/src/actions/governance/proposals/getProposals.test.ts
+++ b/src/actions/governance/proposals/getProposals.test.ts
@@ -144,6 +144,9 @@ describe("getProposals state post-processing", () => {
     } as unknown as Parameters<typeof getProposals>[1]);
 
     expect(result[0]?.state).toBe(1); // ProposalState.Active
+    // Empty-fallback: the API omits `signatures` for multichain proposals
+    // (selector is in the calldata), so `apiProposal.signatures ?? []` yields [].
+    expect(result[0]?.signatures).toEqual([]);
     // Regression guard against #3: the third argument carrying
     // `crossChainQuorums` must reach getProposalsOnChainData. A wiring
     // regression that drops it would still make the state assertion pass.

--- a/src/actions/governance/proposals/getProposals.test.ts
+++ b/src/actions/governance/proposals/getProposals.test.ts
@@ -21,6 +21,7 @@ const mockedOnChain = vi.mocked(getProposalsOnChainData);
 
 const ETHEREUM_CHAIN_ID = 1;
 const MOONBEAM_CHAIN_ID = 1284;
+const MOONRIVER_CHAIN_ID = 1285;
 
 const moonbeamEnv = {
   key: "moonbeam",
@@ -31,8 +32,21 @@ const moonbeamEnv = {
   config: {},
 } as unknown as Record<string, unknown>;
 
+const moonriverEnv = {
+  key: "moonriver",
+  chainId: MOONRIVER_CHAIN_ID,
+  governanceIndexerUrl: "https://mock-indexer.test",
+  contracts: {},
+  custom: {},
+  config: {},
+} as unknown as Record<string, unknown>;
+
 const client = {
   environments: { moonbeam: moonbeamEnv },
+} as unknown as MoonwellClient;
+
+const moonriverClient = {
+  environments: { moonriver: moonriverEnv },
 } as unknown as MoonwellClient;
 
 const makeApiProposal = (chainId: number, proposalId: number): ApiProposal => ({
@@ -257,6 +271,121 @@ describe("getProposals state post-processing", () => {
       expect(result[0]?.state).toBe(terminalState);
     },
   );
+});
+
+describe("getProposals Moonriver via Governor API (MOO-493)", () => {
+  test("fetches Moonriver through the Governor API with chainId 1285 (single call, no Ponder)", async () => {
+    // Moonriver runs one legacy standalone governor, so the migrated path makes
+    // exactly one fetchAllProposals call for chainId 1285 — unlike Moonbeam,
+    // which fans out to chainIds 1 and 1284. The old Ponder path
+    // (getExtendedProposalData → ponder-eu2) is gone: routing through the mocked
+    // fetchAllProposals + getProposalsOnChainData proves it isn't used.
+    mockedFetchAll.mockResolvedValueOnce([
+      makeApiProposal(MOONRIVER_CHAIN_ID, 74),
+    ]);
+    mockedOnChain.mockResolvedValueOnce([defaultOnChain]);
+
+    const result = await getProposals(moonriverClient, {
+      network: "moonriver",
+    } as unknown as Parameters<typeof getProposals>[1]);
+
+    expect(mockedFetchAll).toHaveBeenCalledTimes(1);
+    expect(mockedFetchAll).toHaveBeenCalledWith(moonriverEnv, {
+      chainId: MOONRIVER_CHAIN_ID,
+    });
+    // Same shared pipeline as Moonbeam — crossChainQuorums wiring reaches
+    // getProposalsOnChainData.
+    expect(mockedOnChain).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.anything(),
+      expect.objectContaining({ crossChainQuorums: expect.any(Map) }),
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.chainId).toBe(MOONRIVER_CHAIN_ID);
+    expect(result[0]?.proposalId).toBe(74);
+  });
+
+  test("maps a non-multichain Moonriver proposal to the legacy Proposal shape", async () => {
+    // Moonriver has no multichain governor, so getProposalsOnChainData reports
+    // isMultichain: false → the mapped Proposal must omit the `multichain` field.
+    mockedFetchAll.mockResolvedValueOnce([
+      {
+        ...makeApiProposal(MOONRIVER_CHAIN_ID, 74),
+        proposer: "0x18275952d3ea09d80dbe446d2cba085e01e681b4",
+        description: "# MIP-R10: Test\nbody",
+      },
+    ]);
+    mockedOnChain.mockResolvedValueOnce([
+      { ...defaultOnChain, state: ProposalState.Succeeded, quorum: 123n },
+    ]);
+
+    const result = await getProposals(moonriverClient, {
+      network: "moonriver",
+    } as unknown as Parameters<typeof getProposals>[1]);
+
+    const proposal = result[0];
+    expect(proposal?.chainId).toBe(MOONRIVER_CHAIN_ID);
+    expect(proposal?.id).toBe(74);
+    expect(proposal?.state).toBe(ProposalState.Succeeded);
+    expect(proposal?.proposer).toBe(
+      "0x18275952d3ea09d80dbe446d2cba085e01e681b4",
+    );
+    expect(proposal?.quorum.exponential).toBe(123n);
+    expect(proposal?.multichain).toBeUndefined();
+    expect(proposal?.environment).toBe(moonriverEnv);
+  });
+
+  test("empty Governor API response yields [] with a single chainId-1285 call", async () => {
+    mockedFetchAll.mockResolvedValueOnce([]);
+    mockedOnChain.mockResolvedValueOnce([]);
+
+    const result = await getProposals(moonriverClient, {
+      network: "moonriver",
+    } as unknown as Parameters<typeof getProposals>[1]);
+
+    expect(result).toEqual([]);
+    expect(mockedFetchAll).toHaveBeenCalledTimes(1);
+    expect(mockedFetchAll).toHaveBeenCalledWith(moonriverEnv, {
+      chainId: MOONRIVER_CHAIN_ID,
+    });
+  });
+
+  test("Moonriver indexer outage degrades to [] and reports via onError (does not throw)", async () => {
+    // Regression guard: getMoonriverProposals must mirror the Moonbeam fan-out's
+    // per-chain resilience. A bare throw would reject the whole getProposals
+    // Promise.all and drop Moonbeam/Ethereum results in a combined client.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const onError = vi.fn();
+    const failingEnv = {
+      ...moonriverEnv,
+      onError,
+    } as unknown as Record<string, unknown>;
+    const failingClient = {
+      environments: { moonriver: failingEnv },
+    } as unknown as MoonwellClient;
+    mockedFetchAll.mockRejectedValueOnce(
+      new Error("503 moonriver indexer down"),
+    );
+    mockedOnChain.mockResolvedValueOnce([]);
+
+    const result = await getProposals(failingClient, {
+      network: "moonriver",
+    } as unknown as Parameters<typeof getProposals>[1]);
+
+    expect(result).toEqual([]);
+    expect(onError).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        source: "governance-proposals",
+        chainId: MOONRIVER_CHAIN_ID,
+      }),
+    );
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("chainId=1285"),
+      expect.anything(),
+    );
+  });
 });
 
 describe("getProposals sort + partial-failure behavior", () => {

--- a/src/actions/governance/proposals/getProposals.test.ts
+++ b/src/actions/governance/proposals/getProposals.test.ts
@@ -314,6 +314,13 @@ describe("getProposals Moonriver via Governor API (MOO-493)", () => {
         ...makeApiProposal(MOONRIVER_CHAIN_ID, 74),
         proposer: "0x18275952d3ea09d80dbe446d2cba085e01e681b4",
         description: "# MIP-R10: Test\nbody",
+        // Legacy-governor proposals carry the function signature separately from
+        // the selector-less calldata; the mapper must pass it through so the
+        // frontend can decode the call map.
+        signatures: [
+          "setDirectPrice(address,uint256)",
+          "setFeed(string,address)",
+        ],
       },
     ]);
     mockedOnChain.mockResolvedValueOnce([
@@ -332,6 +339,10 @@ describe("getProposals Moonriver via Governor API (MOO-493)", () => {
       "0x18275952d3ea09d80dbe446d2cba085e01e681b4",
     );
     expect(proposal?.quorum.exponential).toBe(123n);
+    expect(proposal?.signatures).toEqual([
+      "setDirectPrice(address,uint256)",
+      "setFeed(string,address)",
+    ]);
     expect(proposal?.multichain).toBeUndefined();
     expect(proposal?.environment).toBe(moonriverEnv);
   });

--- a/src/actions/governance/proposals/getProposals.ts
+++ b/src/actions/governance/proposals/getProposals.ts
@@ -8,11 +8,7 @@ import { type Proposal, ProposalState } from "../../../types/proposal.js";
 import { type ApiProposal, fetchAllProposals } from "../governor-api-client.js";
 import { resolveIpfsDescriptions } from "../ipfs.js";
 import {
-  appendProposalExtendedData,
   formatApiProposalData,
-  getCrossChainProposalData,
-  getExtendedProposalData,
-  getProposalData,
   getProposalsOnChainData,
   readCrossChainQuorums,
 } from "./common.js";
@@ -49,10 +45,10 @@ export async function getProposals<
   const allProposals = await Promise.all(
     governanceEnvironments.map(async (governanceEnvironment) => {
       if (governanceEnvironment.chainId === moonbeam.id) {
-        // Moonbeam: Use new Governor API
+        // Moonbeam + Ethereum: Governor API (chainIds 1 and 1284)
         return getMoonbeamProposals(governanceEnvironment);
       } else {
-        // Moonriver: Use old Ponder approach
+        // Moonriver: Governor API, single legacy governor (chainId 1285)
         return getMoonriverProposals(governanceEnvironment);
       }
     }),
@@ -109,6 +105,53 @@ async function getMoonbeamProposals(
     }
   });
 
+  return buildProposals(apiProposals, governanceEnvironment);
+}
+
+/**
+ * Fetch proposals for Moonriver using the Governor API.
+ *
+ * Moonriver runs a single legacy standalone governor (no multichain governor),
+ * so we fetch only its chainId from the same lunar indexer and reuse the shared
+ * pipeline. `getProposalsOnChainData` classifies these as non-multichain and
+ * reads state/quorum from the legacy governor (via `getQuorum`).
+ */
+async function getMoonriverProposals(
+  governanceEnvironment: Environment,
+): Promise<Proposal[]> {
+  // Moonriver is a single chain, so there's no other chain to "continue with"
+  // like the Moonbeam fan-out — but a bare throw would reject the whole
+  // `Promise.all` in getProposals and drop Moonbeam/Ethereum results too. Mirror
+  // the per-chain handling getMoonbeamProposals uses: report the outage via
+  // onError and degrade to an empty Moonriver list instead of rejecting.
+  let apiProposals: ApiProposal[] = [];
+  try {
+    apiProposals = await fetchAllProposals(governanceEnvironment, {
+      chainId: moonriver.id,
+    });
+  } catch (reason) {
+    console.warn(
+      `[getProposals] Failed to fetch proposals for chainId=${moonriver.id}; continuing with an empty Moonriver list.`,
+      reason,
+    );
+    governanceEnvironment.onError?.(reason, {
+      source: "governance-proposals",
+      chainId: governanceEnvironment.chainId,
+    });
+  }
+  return buildProposals(apiProposals, governanceEnvironment);
+}
+
+/**
+ * Shared Governor-API pipeline: resolve IPFS descriptions + cross-chain quorums
+ * in parallel, read on-chain data, then map each ApiProposal to a Proposal.
+ * Used by both the Moonbeam/Ethereum and Moonriver paths so the mapping stays
+ * in one place.
+ */
+async function buildProposals(
+  apiProposals: ApiProposal[],
+  governanceEnvironment: Environment,
+): Promise<Proposal[]> {
   // IPFS resolution and cross-chain quorum reads are independent — run them in
   // parallel to save one network round-trip on the proposal list path.
   const [, crossChainQuorums] = await Promise.all([
@@ -194,29 +237,6 @@ async function getMoonbeamProposals(
 
     return proposal;
   });
-
-  return proposals;
-}
-
-/**
- * Fetch proposals for Moonriver using the old Ponder-based approach
- */
-async function getMoonriverProposals(
-  governanceEnvironment: Environment,
-): Promise<Proposal[]> {
-  const [_proposals, _xcProposals, _extendedDatas] = await Promise.all([
-    getProposalData({ environment: governanceEnvironment }),
-    getCrossChainProposalData({ environment: governanceEnvironment }),
-    getExtendedProposalData({ environment: governanceEnvironment }),
-  ]);
-
-  const proposals = [..._proposals, ..._xcProposals];
-
-  proposals.forEach((proposal) => {
-    proposal.environment = governanceEnvironment;
-  });
-
-  appendProposalExtendedData(proposals, _extendedDatas);
 
   return proposals;
 }

--- a/src/actions/governance/proposals/getProposals.ts
+++ b/src/actions/governance/proposals/getProposals.ts
@@ -136,7 +136,7 @@ async function getMoonriverProposals(
     );
     governanceEnvironment.onError?.(reason, {
       source: "governance-proposals",
-      chainId: governanceEnvironment.chainId,
+      chainId: moonriver.id,
     });
   }
   return buildProposals(apiProposals, governanceEnvironment);

--- a/src/actions/governance/proposals/getProposals.ts
+++ b/src/actions/governance/proposals/getProposals.ts
@@ -223,7 +223,10 @@ async function buildProposals(
       description: apiProposal.description,
       targets: apiProposal.targets,
       calldatas: apiProposal.calldatas,
-      signatures: [],
+      // Legacy-governor proposals (Moonriver, early Moonbeam) carry the function
+      // signature separately from the selector-less calldata; pass it through so
+      // consumers can decode the call. Empty for multichain-governor proposals.
+      signatures: apiProposal.signatures ?? [],
       stateChanges: formattedData.stateChanges,
       environment: governanceEnvironment,
     };


### PR DESCRIPTION
## Summary

Migrates Moonriver (chainId 1285) governance **proposal fetching** off the legacy Ponder GraphQL endpoint (`ponder-eu2.moonwell.fi`) onto the same lunar-indexer **Governor API** that already serves Moonbeam and Ethereum. SDK-only — the lunar-indexer already indexes the Moonriver governor and the worker `/api/v1/governor` route already accepts `chainId=1285` (verified live: `GET …/api/v1/governor/proposals?chainId=1285` → 200 with non-empty results).

Linear: [MOO-493](https://linear.app/moonwell/issue/MOO-493) · Milestone: Lunar Indexer migration

## What changed

- **`governor-api-client.ts`** — add `1285` to `SUPPORTED_GOVERNOR_CHAIN_IDS`; doc comments updated.
- **`getProposals.ts`** — extract a shared `buildProposals` pipeline (IPFS + cross-chain quorums → `getProposalsOnChainData` → map). Moonriver now fetches via `fetchAllProposals(env, { chainId: 1285 })` and **reuses the Moonbeam mapping** instead of the old Ponder path.
- **`getProposal.ts`** — rename `getMoonbeamProposal` → `getGovernorApiProposal` (now serves Moonbeam, Ethereum, and Moonriver) and route the single-proposal Moonriver case through `fetchProposal(env, 1285, proposalId)` + the shared pipeline.
- **`common.ts`** — remove the now-orphaned Ponder functions (`getProposalData`, `getCrossChainProposalData`, `getExtendedProposalData`, `appendProposalExtendedData`), the `PonderExtendedProposalData` type, and the imports they alone pulled in (`lodash/last`, `postWithRetry`, `moonriver`, `Proposal` type). `axios.defaults.timeout` is intentionally retained (it governs the live Governor API calls too).

Moonriver has only a legacy `governor` (no `multichainGovernor`/`voteCollector`), so its proposals classify as **non-multichain** and read state + quorum (via `getQuorum()`) from the legacy governor — exactly as `getProposalsOnChainData` already does for non-1284 chains.

## Review-driven hardening

This PR includes fixes for issues surfaced during review:

- **Resilience/observability:** `getMoonriverProposals` now degrades to `[]` and reports via `onError` on an indexer outage instead of rejecting the whole `getProposals` call (which would also drop Moonbeam/Ethereum results in a combined client). Mirrors the Moonbeam fan-out and restores the deleted Ponder path's behavior.
- **Classification correctness:** `classifyProposalMultichain` gains a `hasMultichainGovernor` gate (default `true`, so Moonbeam/Ethereum behavior is unchanged) so a failed Artemis `proposalCount` read can no longer misclassify legacy-only Moonriver as multichain — honoring the "Moonriver proposals are never multichain" invariant.
- **Silent failure:** `getProposalsOnChainData` now routes swallowed quorum-read failures through `onError`, consistent with its sibling state/proposals reads.

## Out of scope (intentionally untouched)

- Moonriver's **lending** `indexerUrl` (`https://ponder.moonwell.fi`) in `moonriver/environment.ts` — still used by core markets/positions. This ticket is governor-only.

## Public API

No breaking changes — `SUPPORTED_GOVERNOR_CHAIN_IDS` grows additively, request/response shapes are identical, and none of the removed functions were re-exported from the package root. Changeset: `patch`.

## Testing

- New Moonriver (1285) cases in `getProposals.test.ts` / `getProposal.test.ts` prove routing through the Governor API with chainId 1285, correct non-multichain `Proposal` shape, and that the Ponder path is not invoked. Plus outage→`[]`+`onError`, empty-results, and `classifyProposalMultichain` legacy-only-chain coverage.
- `getUserVoteReceipt.test.ts` updated for the 3-chain fan-out (1285 now included).
- ✅ `pnpm typecheck` · ✅ `pnpm test` (562 passed / 33 files) · ✅ `pnpm lint` · ✅ `pnpm gate:run` (coverage +1.0pp lines / +1.51pp functions; duplication down)

🤖 Generated with [Claude Code](https://claude.com/claude-code)