### PR TITLE
feat(governance): surface indexer snapshotBlocks on Proposal (MOO-499)

### DIFF
--- a/.changeset/moo-499-proposal-snapshot-blocks.md
+++ b/.changeset/moo-499-proposal-snapshot-blocks.md
@@ -1,0 +1,5 @@
+---
+"@moonwell-fi/moonwell-sdk": patch
+---
+
+Surface the lunar-indexer's per-chain `snapshotBlocks` on the `Proposal` type (MOO-499). The indexer now resolves and stores the authoritative voting-power snapshot block for each chain (`mainnet`, `base`, `optimism`, `moonbeam`) on the proposal record; `getProposal`/`getProposals` now pass that map straight through. Consumers can read voting power directly at these blocks instead of resolving the snapshot timestamp to a block client-side, which is both faster and more correct (the indexer reads the real on-chain snapshot block, which can differ by one from a timestamp-derived block). The field is optional and absent for proposals indexed before it existed and for on-chain (Moonriver) proposals.

--- a/src/actions/governance/governor-api-client.ts
+++ b/src/actions/governance/governor-api-client.ts
@@ -113,6 +113,12 @@ export type ApiProposal = {
   timestamp: number;
   transactionHash: string;
   stateChanges?: ApiProposalStateChange[];
+  /**
+   * Per-chain voting-power snapshot blocks resolved by the indexer, keyed by
+   * chain name (`mainnet`, `base`, `optimism`, `moonbeam`). Decimal strings.
+   * Omitted for proposals indexed before this field existed.
+   */
+  snapshotBlocks?: Record<string, string>;
 };
 
 export type ApiVote = {

--- a/src/actions/governance/proposals/getProposal.test.ts
+++ b/src/actions/governance/proposals/getProposal.test.ts
@@ -478,3 +478,44 @@ describe("getProposal mainnet routing", () => {
     expect(mockedFetchProposal).not.toHaveBeenCalled();
   });
 });
+
+describe("getProposal snapshotBlocks passthrough", () => {
+  test("surfaces the indexer's per-chain snapshotBlocks unchanged", async () => {
+    const snapshotBlocks = {
+      mainnet: "25395850",
+      base: "47807867",
+      optimism: "153403152",
+      moonbeam: "16179174",
+    };
+    mockedFetchProposal.mockResolvedValueOnce({
+      ...baseApiProposal,
+      chainId: MOONBEAM_CHAIN_ID,
+      snapshotBlocks,
+    });
+    mockedOnChain.mockResolvedValueOnce([defaultOnChain]);
+
+    const result = await getProposal(client, {
+      network: "moonbeam",
+      proposalId: 7,
+      chainId: MOONBEAM_CHAIN_ID,
+    } as unknown as Parameters<typeof getProposal>[1]);
+
+    expect(result?.snapshotBlocks).toEqual(snapshotBlocks);
+  });
+
+  test("leaves snapshotBlocks undefined for proposals indexed before the field existed", async () => {
+    mockedFetchProposal.mockResolvedValueOnce({
+      ...baseApiProposal,
+      chainId: MOONBEAM_CHAIN_ID,
+    });
+    mockedOnChain.mockResolvedValueOnce([defaultOnChain]);
+
+    const result = await getProposal(client, {
+      network: "moonbeam",
+      proposalId: 7,
+      chainId: MOONBEAM_CHAIN_ID,
+    } as unknown as Parameters<typeof getProposal>[1]);
+
+    expect(result?.snapshotBlocks).toBeUndefined();
+  });
+});

--- a/src/actions/governance/proposals/getProposal.ts
+++ b/src/actions/governance/proposals/getProposal.ts
@@ -185,6 +185,10 @@ async function getMoonbeamProposal(
     environment: governanceEnvironment,
   };
 
+  if (apiProposal.snapshotBlocks) {
+    proposal.snapshotBlocks = apiProposal.snapshotBlocks;
+  }
+
   if (isMultichain) {
     proposal.multichain = {
       id: apiProposal.proposalId,

--- a/src/actions/governance/proposals/getProposals.test.ts
+++ b/src/actions/governance/proposals/getProposals.test.ts
@@ -337,3 +337,62 @@ describe("getProposals sort + partial-failure behavior", () => {
     );
   });
 });
+
+describe("getProposals snapshotBlocks passthrough", () => {
+  const snapshotBlocks = {
+    mainnet: "25395850",
+    base: "47807867",
+    optimism: "153403152",
+    moonbeam: "16179174",
+  };
+
+  test("surfaces the indexer's per-chain snapshotBlocks on each listed proposal unchanged", async () => {
+    mockedFetchAll
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        { ...makeApiProposal(MOONBEAM_CHAIN_ID, 50), snapshotBlocks },
+      ]);
+    mockedOnChain.mockResolvedValueOnce([defaultOnChain]);
+
+    const result = await getProposals(client, {
+      network: "moonbeam",
+    } as unknown as Parameters<typeof getProposals>[1]);
+
+    // Surfaced verbatim — no key normalization, no derivation from blockNumber.
+    expect(result[0]?.snapshotBlocks).toEqual(snapshotBlocks);
+  });
+
+  test("leaves snapshotBlocks undefined for proposals indexed before the field existed", async () => {
+    mockedFetchAll
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([makeApiProposal(MOONBEAM_CHAIN_ID, 51)]);
+    mockedOnChain.mockResolvedValueOnce([defaultOnChain]);
+
+    const result = await getProposals(client, {
+      network: "moonbeam",
+    } as unknown as Parameters<typeof getProposals>[1]);
+
+    expect(result[0]?.snapshotBlocks).toBeUndefined();
+  });
+
+  test("passes a partial snapshotBlocks map through without filling in the missing chains", async () => {
+    // The indexer may omit a chain (e.g. it hasn't resolved that chain's
+    // snapshot yet). The SDK must not invent or backfill blocks — the frontend
+    // relies on the absence to fall back to timestamp resolution per chain.
+    const partial = { mainnet: "25395850", base: "47807867" };
+    mockedFetchAll
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        { ...makeApiProposal(MOONBEAM_CHAIN_ID, 52), snapshotBlocks: partial },
+      ]);
+    mockedOnChain.mockResolvedValueOnce([defaultOnChain]);
+
+    const result = await getProposals(client, {
+      network: "moonbeam",
+    } as unknown as Parameters<typeof getProposals>[1]);
+
+    expect(result[0]?.snapshotBlocks).toEqual(partial);
+    expect(result[0]?.snapshotBlocks?.optimism).toBeUndefined();
+    expect(result[0]?.snapshotBlocks?.moonbeam).toBeUndefined();
+  });
+});

--- a/src/actions/governance/proposals/getProposals.ts
+++ b/src/actions/governance/proposals/getProposals.ts
@@ -185,6 +185,10 @@ async function getMoonbeamProposals(
       environment: governanceEnvironment,
     };
 
+    if (apiProposal.snapshotBlocks) {
+      proposal.snapshotBlocks = apiProposal.snapshotBlocks;
+    }
+
     if (isMultichain) {
       proposal.multichain = {
         id: apiProposal.proposalId,

--- a/src/types/proposal.ts
+++ b/src/types/proposal.ts
@@ -23,6 +23,17 @@ export type Proposal = {
     id: number;
     votesCollected: boolean;
   };
+  /**
+   * Authoritative per-chain voting-power snapshot blocks resolved by the
+   * lunar-indexer, keyed by chain name (`mainnet` → 1, `base` → 8453,
+   * `optimism` → 10, `moonbeam` → 1284). Block numbers are decimal strings.
+   *
+   * Present on indexer-sourced multichain proposals; absent for older
+   * proposals indexed before the field existed and for on-chain (Moonriver)
+   * proposals. Consumers reading voting power should prefer these blocks over
+   * resolving the snapshot timestamp to a block client-side.
+   */
+  snapshotBlocks?: Record<string, string>;
   //proposal extended data
   title?: string;
   subtitle?: string;


### PR DESCRIPTION
## Summary

The lunar-indexer now resolves and stores the **authoritative per-chain voting-power snapshot block** for each proposal and ships it as a `snapshotBlocks` map (keyed by chain name: `mainnet`/`base`/`optimism`/`moonbeam`). This PR surfaces that map on the SDK `Proposal` type so consumers can read voting power directly at those blocks instead of resolving the snapshot timestamp → block client-side.

Part of [MOO-499](https://linear.app/moonwell/issue/MOO-499/use-lunar-indexer-to-determine-voting-power-on-proposal-page). Companion frontend PR consumes this field.

## Changes

- `Proposal.snapshotBlocks?: Record<string, string>` and `ApiProposal.snapshotBlocks?` added.
- `getProposal` / `getProposals` pass the indexer value straight through — **verbatim**, no key normalization, no backfilling of missing chains.
- The field is **optional**: absent for proposals indexed before it existed and for the on-chain Moonriver path (`common.ts`), whose absence correctly triggers the frontend's per-chain fallback.
- Changeset (`patch`).

## Tests

Added passthrough / undefined / partial-map coverage for both `getProposal` and `getProposals`. Full suite: `getProposal.test.ts` + `getProposals.test.ts` green (`pnpm test`), `pnpm typecheck` clean.

## Notes

Additive and optional — no behavior change for existing consumers. Once released, the companion frontend can drop its temporary patch-package patch and bump the SDK dependency.