### PR TITLE
Remove dead Ponder indexer fetches from snapshot actions

### DIFF
--- a/.changeset/brave-mirrors-tell.md
+++ b/.changeset/brave-mirrors-tell.md
@@ -1,0 +1,5 @@
+---
+"@moonwell-fi/moonwell-sdk": patch
+---
+
+Removed the dead Ponder indexer fetches. `getStakingSnapshots`, `getCirculatingSupplySnapshots`, `getMarketSnapshots` (core), and `getUserPositionSnapshots` now return `[]` for environments without a `lunarIndexerUrl` (Moonriver) instead of querying the decommissioned Ponder API. No public type changes — the deprecated `Environment.indexerUrl` field remains for now and its removal is tracked separately (MOO-537).

--- a/src/actions/core/markets/getMarketSnapshots.test.ts
+++ b/src/actions/core/markets/getMarketSnapshots.test.ts
@@ -182,7 +182,7 @@ describe("trimLeadingEmptySnapshots (unit)", () => {
   });
 
   test("trims leading zero snapshots (descending order)", () => {
-    // Ponder returns newest-first; function must still work
+    // The indexer may return newest-first; function must still work
     const snapshots = [
       makeMarketSnapshot(DAY2, 100, 50),
       makeMarketSnapshot(DAY1, 0, 0),
@@ -369,107 +369,27 @@ describe("fetchIsolatedMarketSnapshots — stkWELL workaround (unit)", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Core market snapshots — Ponder path (indexerUrl, no lunarIndexerUrl)
+// Core market snapshots — no lunarIndexerUrl (moonriver)
 // ---------------------------------------------------------------------------
 
-describe("core market snapshots — Ponder path (indexerUrl, no lunarIndexerUrl)", () => {
+describe("core market snapshots — no lunarIndexerUrl (moonriver)", () => {
   afterEach(() => {
     vi.clearAllMocks();
   });
 
-  const MOCK_PONDER_URL = "https://mock-ponder.test";
   const CORE_MARKET_ADDRESS =
     "0xaaaa000000000000000000000000000000000001" as `0x${string}`;
   const MOONRIVER_CHAIN_ID = 1285;
 
-  function makeMoonriverClient(): MoonwellClient {
-    return {
-      environments: {
-        moonriver: {
-          chainId: MOONRIVER_CHAIN_ID,
-          lunarIndexerUrl: undefined,
-          indexerUrl: MOCK_PONDER_URL,
-          config: {
-            markets: {},
-            tokens: {},
-            vaults: {},
-            morphoMarkets: {},
-            contracts: {},
-          },
-        } as unknown as Environment,
-      },
-    } as unknown as MoonwellClient;
-  }
-
-  test("calls axios.post with indexerUrl when no lunarIndexerUrl", async () => {
-    vi.spyOn(axios, "post").mockResolvedValueOnce({
-      data: {
-        data: {
-          marketDailySnapshots: {
-            items: [],
-            pageInfo: { hasNextPage: false, endCursor: "" },
-          },
-        },
-      },
-    });
-
-    await getMarketSnapshots(makeMoonriverClient(), {
-      chainId: MOONRIVER_CHAIN_ID,
-      type: "core",
-      marketId: CORE_MARKET_ADDRESS,
-    });
-
-    expect(vi.mocked(axios.post)).toHaveBeenCalledWith(
-      MOCK_PONDER_URL,
-      expect.objectContaining({
-        query: expect.stringContaining(CORE_MARKET_ADDRESS.toLowerCase()),
-      }),
-    );
-  });
-
-  test("returns mapped snapshots from Ponder", async () => {
-    vi.spyOn(axios, "post").mockResolvedValueOnce({
-      data: {
-        data: {
-          marketDailySnapshots: {
-            items: [
-              {
-                totalBorrows: 100,
-                totalBorrowsUSD: 100,
-                totalSupplies: 1000,
-                totalSuppliesUSD: 1000,
-                totalLiquidity: 900,
-                totalLiquidityUSD: 900,
-                baseSupplyApy: 0.05,
-                baseBorrowApy: 0.08,
-                timestamp: 1704067200, // 2024-01-01 00:00:00 UTC (start of day)
-              },
-            ],
-            pageInfo: { hasNextPage: false, endCursor: "" },
-          },
-        },
-      },
-    });
-
-    const result = await getMarketSnapshots(makeMoonriverClient(), {
-      chainId: MOONRIVER_CHAIN_ID,
-      type: "core",
-      marketId: CORE_MARKET_ADDRESS,
-    });
-
-    expect(result).toHaveLength(1);
-    expect(result[0]?.totalSupply).toBe(1000);
-    expect(result[0]?.totalBorrows).toBe(100);
-    expect(result[0]?.baseSupplyApy).toBe(0.05);
-  });
-
-  test("returns [] when both lunarIndexerUrl and indexerUrl are absent", async () => {
+  test("returns [] without making any HTTP call", async () => {
+    const postSpy = vi.spyOn(axios, "post");
+    const onErrorSpy = vi.fn();
     const noUrlClient = {
       environments: {
         moonriver: {
           chainId: MOONRIVER_CHAIN_ID,
           lunarIndexerUrl: undefined,
-          indexerUrl: undefined,
+          onError: onErrorSpy,
           config: {
             markets: {},
             tokens: {},
@@ -488,6 +408,9 @@ describe("core market snapshots — Ponder path (indexerUrl, no lunarIndexerUrl)
     });
 
     expect(result).toEqual([]);
-    expect(vi.mocked(axios.post)).not.toHaveBeenCalled();
+    expect(postSpy).not.toHaveBeenCalled();
+    // Guards against the empty result coming from the Lunar catch path
+    // instead of the intentional missing-lunarIndexerUrl branch.
+    expect(onErrorSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/actions/core/markets/getMarketSnapshots.ts
+++ b/src/actions/core/markets/getMarketSnapshots.ts
@@ -11,7 +11,6 @@ import { buildMarketId } from "../../../common/lunar-indexer-helpers.js";
 import type { NetworkParameterType } from "../../../common/types.js";
 import type { Chain, Environment } from "../../../environments/index.js";
 import type { MarketSnapshot } from "../../../types/market.js";
-import { postWithRetry } from "../../axiosWithRetry.js";
 import {
   DEFAULT_LUNAR_TIMEOUT_MS,
   createLunarIndexerClient,
@@ -141,23 +140,7 @@ async function fetchCoreMarketSnapshots(
   endTime?: number,
 ): Promise<MarketSnapshot[]> {
   if (!environment.lunarIndexerUrl) {
-    if (!environment.indexerUrl) return [];
-    try {
-      return await fetchCoreMarketSnapshotsFromPonder(
-        marketAddress,
-        environment,
-      );
-    } catch (error) {
-      console.warn(
-        `[getMarketSnapshots] Ponder failed for chain ${environment.chainId}:`,
-        error,
-      );
-      environment.onError?.(error, {
-        source: "market-snapshots-ponder",
-        chainId: environment.chainId,
-      });
-      return [];
-    }
+    return [];
   }
   try {
     return await fetchCoreMarketSnapshotsFromLunar(
@@ -178,106 +161,6 @@ async function fetchCoreMarketSnapshots(
     });
     return [];
   }
-}
-
-async function fetchCoreMarketSnapshotsFromPonder(
-  marketAddress: string,
-  environment: Environment,
-): Promise<MarketSnapshot[]> {
-  if (!environment.indexerUrl) return [];
-
-  interface MarketDailyData {
-    totalBorrows: number;
-    totalBorrowsUSD: number;
-    totalSupplies: number;
-    totalSuppliesUSD: number;
-    totalLiquidity: number;
-    totalLiquidityUSD: number;
-    baseSupplyApy: number;
-    baseBorrowApy: number;
-    timestamp: number;
-  }
-
-  const dailyData: MarketDailyData[] = [];
-  let hasNextPage = true;
-  let endCursor: string | undefined;
-
-  while (hasNextPage) {
-    const result = await postWithRetry<{
-      data: {
-        marketDailySnapshots: {
-          items: MarketDailyData[];
-          pageInfo: { hasNextPage: boolean; endCursor: string };
-        };
-      };
-    }>(environment.indexerUrl, {
-      query: `
-          query {
-            marketDailySnapshots (
-              limit: 1000,
-              orderBy: "timestamp"
-              orderDirection: "desc"
-              where: {marketAddress: "${marketAddress.toLowerCase()}", chainId: ${environment.chainId}}
-              ${endCursor ? `after: "${endCursor}"` : ""}
-            ) {
-              items {
-                totalBorrows
-                totalBorrowsUSD
-                totalSupplies
-                totalSuppliesUSD
-                totalLiquidity
-                totalLiquidityUSD
-                baseSupplyApy
-                baseBorrowApy
-                timestamp
-              }
-              pageInfo {
-                hasNextPage
-                endCursor
-              }
-            }
-          }
-        `,
-    });
-
-    dailyData.push(
-      ...result.data.data.marketDailySnapshots.items.filter(
-        (f: { timestamp: number }) => isStartOfDay(f.timestamp),
-      ),
-    );
-    hasNextPage = result.data.data.marketDailySnapshots.pageInfo.hasNextPage;
-    endCursor = result.data.data.marketDailySnapshots.pageInfo.endCursor;
-  }
-
-  if (dailyData.length === 0) return [];
-
-  return dailyData.map((point) => {
-    const supplied = Number(point.totalSupplies);
-    const borrow = Number(point.totalBorrows);
-    const borrowUsd = Number(point.totalBorrowsUSD);
-    const suppliedUsd = Number(point.totalSuppliesUSD);
-    const liquidity = Math.max(point.totalLiquidity, 0);
-    const liquidityUsd = Math.max(point.totalLiquidityUSD, 0);
-    const price = suppliedUsd / supplied;
-
-    return {
-      marketId: marketAddress.toLowerCase(),
-      chainId: environment.chainId,
-      timestamp: point.timestamp * 1000,
-      totalSupply: supplied,
-      totalSupplyUsd: suppliedUsd,
-      totalBorrows: borrow,
-      totalBorrowsUsd: borrowUsd,
-      totalLiquidity: liquidity,
-      totalLiquidityUsd: liquidityUsd,
-      totalReallocatableLiquidity: 0,
-      totalReallocatableLiquidityUsd: 0,
-      baseSupplyApy: point.baseSupplyApy,
-      baseBorrowApy: point.baseBorrowApy,
-      collateralTokenPrice: price,
-      loanTokenPrice: price,
-    };
-  });
 }
 
 async function fetchCoreMarketSnapshotsFromLunar(

--- a/src/actions/core/user-positions/getUserPositionSnapshots.test.ts
+++ b/src/actions/core/user-positions/getUserPositionSnapshots.test.ts
@@ -6,95 +6,28 @@ import type { Environment } from "../../../environments/index.js";
 import { getUserPositionSnapshots } from "./getUserPositionSnapshots.js";
 
 // ---------------------------------------------------------------------------
-// Ponder path unit tests
+// No lunarIndexerUrl unit tests
 // ---------------------------------------------------------------------------
 
-describe("getUserPositionSnapshots — Ponder path (indexerUrl, no lunarIndexerUrl)", () => {
-  const MOCK_PONDER_URL = "https://mock-ponder.test";
+describe("getUserPositionSnapshots — no lunarIndexerUrl (moonriver)", () => {
   const MOONRIVER_CHAIN_ID = 1285;
   const USER_ADDRESS =
     "0xD90AF108299c5F14418a69D074D0717b612BC016" as `0x${string}`;
-
-  function makeMoonriverClient(): MoonwellClient {
-    return {
-      environments: {
-        moonriver: {
-          chainId: MOONRIVER_CHAIN_ID,
-          lunarIndexerUrl: undefined,
-          indexerUrl: MOCK_PONDER_URL,
-          config: { tokens: {} },
-        } as unknown as Environment,
-      },
-    } as unknown as MoonwellClient;
-  }
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  test("calls axios.post with indexerUrl when no lunarIndexerUrl", async () => {
-    vi.spyOn(axios, "post").mockResolvedValueOnce({
-      data: {
-        data: {
-          accountDailySnapshots: {
-            items: [],
-            pageInfo: { hasNextPage: false, endCursor: "" },
-          },
-        },
-      },
-    });
-
-    await getUserPositionSnapshots(makeMoonriverClient(), {
-      chainId: MOONRIVER_CHAIN_ID,
-      userAddress: USER_ADDRESS,
-    });
-
-    expect(vi.mocked(axios.post)).toHaveBeenCalledWith(
-      MOCK_PONDER_URL,
-      expect.objectContaining({
-        query: expect.stringContaining(USER_ADDRESS.toLowerCase()),
-      }),
-    );
-  });
-
-  test("returns mapped snapshot data from Ponder", async () => {
-    vi.spyOn(axios, "post").mockResolvedValueOnce({
-      data: {
-        data: {
-          accountDailySnapshots: {
-            items: [
-              {
-                timestamp: 1704067200, // 2024-01-01 00:00:00 UTC (start of day)
-                totalBorrowsUSD: "500",
-                totalSuppliesUSD: "2000",
-                totalCollateralUSD: "1500",
-              },
-            ],
-            pageInfo: { hasNextPage: false, endCursor: "" },
-          },
-        },
-      },
-    });
-
-    const result = await getUserPositionSnapshots(makeMoonriverClient(), {
-      chainId: MOONRIVER_CHAIN_ID,
-      userAddress: USER_ADDRESS,
-    });
-
-    expect(result).toHaveLength(1);
-    expect(result[0]?.totalSupplyUsd).toBe(2000);
-    expect(result[0]?.totalBorrowsUsd).toBe(500);
-    expect(result[0]?.totalCollateralUsd).toBe(1500);
-  });
-
-  test("returns [] when both lunarIndexerUrl and indexerUrl are absent", async () => {
+  test("returns [] without making any HTTP call", async () => {
     const postSpy = vi.spyOn(axios, "post");
+    const getSpy = vi.spyOn(axios, "get");
+    const onErrorSpy = vi.fn();
     const noUrlClient = {
       environments: {
         moonriver: {
           chainId: MOONRIVER_CHAIN_ID,
           lunarIndexerUrl: undefined,
-          indexerUrl: undefined,
+          onError: onErrorSpy,
         } as unknown as Environment,
       },
     } as unknown as MoonwellClient;
@@ -106,6 +39,10 @@ describe("getUserPositionSnapshots — Ponder path (indexerUrl, no lunarIndexerU
 
     expect(result).toEqual([]);
     expect(postSpy).not.toHaveBeenCalled();
+    expect(getSpy).not.toHaveBeenCalled();
+    // Guards against the empty result coming from the Lunar catch path
+    // instead of the intentional missing-lunarIndexerUrl branch.
+    expect(onErrorSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/src/actions/core/user-positions/getUserPositionSnapshots.ts
+++ b/src/actions/core/user-positions/getUserPositionSnapshots.ts
@@ -5,13 +5,11 @@ import {
   applyGranularity,
   calculateTimeRange,
   getEnvironmentFromArgs,
-  isStartOfDay,
   toApiGranularity,
 } from "../../../common/index.js";
 import type { NetworkParameterType } from "../../../common/types.js";
 import type { Chain, Environment } from "../../../environments/index.js";
 import type { UserPositionSnapshot } from "../../../types/userPosition.js";
-import { postWithRetry } from "../../axiosWithRetry.js";
 import {
   DEFAULT_LUNAR_TIMEOUT_MS,
   createLunarIndexerClient,
@@ -54,8 +52,7 @@ export type GetUserPositionSnapshotsReturnType = Promise<
  * @remarks
  * - Default behavior (no time parameters): Returns 365 days of history
  * - Parameter priority: Custom timestamps > period > default (365 days)
- * - When using Lunar Indexer, custom time ranges are supported
- * - Snapshots are filtered to start-of-day for "1d" granularity
+ * - Environments without a Lunar Indexer configured return an empty array
  */
 export async function getUserPositionSnapshots<
   environments,
@@ -89,23 +86,7 @@ async function fetchUserPositionSnapshots(
   granularity?: "6h" | "1d",
 ): Promise<UserPositionSnapshot[]> {
   if (!environment.lunarIndexerUrl) {
-    if (!environment.indexerUrl) return [];
-    try {
-      return await fetchUserPositionSnapshotsFromPonder(
-        userAddress,
-        environment,
-      );
-    } catch (error) {
-      console.warn(
-        `[getUserPositionSnapshots] Ponder failed for chain ${environment.chainId}:`,
-        error,
-      );
-      environment.onError?.(error, {
-        source: "user-position-snapshots-ponder",
-        chainId: environment.chainId,
-      });
-      return [];
-    }
+    return [];
   }
   try {
     return await fetchUserPositionSnapshotsFromLunar(
@@ -185,74 +166,4 @@ async function fetchUserPositionSnapshotsFromLunar(
     snapshots.slice(firstNonZeroIndex),
     resolvedGranularity,
   );
-}
-
-async function fetchUserPositionSnapshotsFromPonder(
-  userAddress: Address,
-  environment: Environment,
-): Promise<UserPositionSnapshot[]> {
-  if (!environment.indexerUrl) return [];
-
-  interface UserDailyData {
-    totalBorrowsUSD: string;
-    totalSuppliesUSD: string;
-    totalCollateralUSD: string;
-    timestamp: number;
-  }
-
-  const dailyData: UserDailyData[] = [];
-  let hasNextPage = true;
-  let endCursor: string | undefined;
-
-  while (hasNextPage) {
-    const result = await postWithRetry<{
-      data: {
-        accountDailySnapshots: {
-          items: UserDailyData[];
-          pageInfo: { hasNextPage: boolean; endCursor: string };
-        };
-      };
-    }>(environment.indexerUrl, {
-      query: `
-          query {
-            accountDailySnapshots(
-              limit: 365,
-              orderDirection: "desc",
-              orderBy: "timestamp",
-              where: { accountAddress: "${userAddress.toLowerCase()}", chainId: ${environment.chainId} }
-              ${endCursor ? `after: "${endCursor}"` : ""}
-            ) {
-              items {
-                timestamp,
-                totalBorrowsUSD,
-                totalSuppliesUSD,
-                totalCollateralUSD,
-              }
-              pageInfo {
-                hasNextPage
-                endCursor
-              }
-            }
-          }
-        `,
-    });
-
-    dailyData.push(
-      ...result.data.data.accountDailySnapshots.items.filter(
-        (f: { timestamp: number }) => isStartOfDay(f.timestamp),
-      ),
-    );
-    hasNextPage = result.data.data.accountDailySnapshots.pageInfo.hasNextPage;
-    endCursor = result.data.data.accountDailySnapshots.pageInfo.endCursor;
-  }
-
-  if (dailyData.length === 0) return [];
-
-  return dailyData.map((point) => ({
-    chainId: environment.chainId,
-    timestamp: point.timestamp * 1000,
-    totalSupplyUsd: Number(point.totalSuppliesUSD),
-    totalBorrowsUsd: Number(point.totalBorrowsUSD),
-    totalCollateralUsd: Number(point.totalCollateralUSD),
-  }));
 }

--- a/src/actions/governance/getCirculatingSupplySnapshots.test.ts
+++ b/src/actions/governance/getCirculatingSupplySnapshots.test.ts
@@ -132,83 +132,17 @@ describe("getCirculatingSupplySnapshots — lunar indexer path", () => {
   });
 });
 
-describe("getCirculatingSupplySnapshots — Ponder path (indexerUrl, no lunarIndexerUrl)", () => {
-  const MOCK_PONDER_URL = "https://mock-ponder.test";
+describe("getCirculatingSupplySnapshots — no lunarIndexerUrl (moonriver)", () => {
   const MOONRIVER_CHAIN_ID = 1285;
-  const MFAM_ADDRESS = "0xBB0E17EF65F82Ab018d8EDd776e8DD940327B28b";
 
-  const ponderClient = {
-    environments: {
-      moonriver: {
-        chainId: MOONRIVER_CHAIN_ID,
-        lunarIndexerUrl: undefined,
-        indexerUrl: MOCK_PONDER_URL,
-        config: {
-          tokens: {
-            MFAM: { address: MFAM_ADDRESS, symbol: "MFAM", decimals: 18 },
-          },
-        },
-      },
-    },
-  } as never;
-
-  test("calls axios.post with indexerUrl when no lunarIndexerUrl", async () => {
-    const postSpy = vi.spyOn(axios, "post").mockResolvedValueOnce({
-      status: 200,
-      data: { data: { circulatingSupplyDailySnapshots: { items: [] } } },
-    });
-    const getSpy = vi.spyOn(axios, "get");
-
-    await getCirculatingSupplySnapshots(ponderClient, {
-      chainId: MOONRIVER_CHAIN_ID,
-    });
-
-    expect(postSpy).toHaveBeenCalledWith(
-      MOCK_PONDER_URL,
-      expect.objectContaining({
-        query: expect.stringContaining(`chainId: ${MOONRIVER_CHAIN_ID}`),
-      }),
-    );
-    expect(getSpy).not.toHaveBeenCalled();
-  });
-
-  test("returns mapped snapshot data from Ponder", async () => {
-    vi.spyOn(axios, "post").mockResolvedValueOnce({
-      status: 200,
-      data: {
-        data: {
-          circulatingSupplyDailySnapshots: {
-            items: [
-              {
-                chainId: MOONRIVER_CHAIN_ID,
-                tokenAddress: MFAM_ADDRESS,
-                circulatingSupply: 500_000_000,
-                timestamp: 1700000000,
-              },
-            ],
-          },
-        },
-      },
-    });
-
-    const result = await getCirculatingSupplySnapshots(ponderClient, {
-      chainId: MOONRIVER_CHAIN_ID,
-    });
-
-    expect(result).toHaveLength(1);
-    expect(result[0]?.circulatingSupply).toBe(500_000_000);
-    expect(result[0]?.chainId).toBe(MOONRIVER_CHAIN_ID);
-    expect(result[0]?.token.symbol).toBe("MFAM");
-  });
-
-  test("returns [] when both lunarIndexerUrl and indexerUrl are absent", async () => {
+  test("returns [] without making any HTTP call", async () => {
     const postSpy = vi.spyOn(axios, "post");
+    const getSpy = vi.spyOn(axios, "get");
     const noUrlClient = {
       environments: {
         moonriver: {
           chainId: MOONRIVER_CHAIN_ID,
           lunarIndexerUrl: undefined,
-          indexerUrl: undefined,
           config: { tokens: {} },
         },
       },
@@ -220,6 +154,7 @@ describe("getCirculatingSupplySnapshots — Ponder path (indexerUrl, no lunarInd
 
     expect(result).toEqual([]);
     expect(postSpy).not.toHaveBeenCalled();
+    expect(getSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/src/actions/governance/getCirculatingSupplySnapshots.ts
+++ b/src/actions/governance/getCirculatingSupplySnapshots.ts
@@ -1,9 +1,9 @@
 import type { MoonwellClient } from "../../client/createMoonwellClient.js";
 import { getEnvironmentFromArgs } from "../../common/index.js";
 import type { OptionalNetworkParameterType } from "../../common/types.js";
-import type { Chain, Environment } from "../../environments/index.js";
+import type { Chain } from "../../environments/index.js";
 import type { CirculatingSupplySnapshot } from "../../types/circulatingSupply.js";
-import { getWithRetry, postWithRetry } from "../axiosWithRetry.js";
+import { getWithRetry } from "../axiosWithRetry.js";
 
 export type GetCirculatingSupplySnapshotsParameters<
   environments,
@@ -74,9 +74,7 @@ export async function getCirculatingSupplySnapshots<
   }
 
   if (!environment.lunarIndexerUrl) {
-    return environment.indexerUrl
-      ? fetchCirculatingSupplyFromPonder(environment)
-      : [];
+    return [];
   }
 
   try {
@@ -109,73 +107,6 @@ export async function getCirculatingSupplySnapshots<
       source: "circulating-supply",
       chainId: environment.chainId,
     });
-    return [];
-  }
-}
-
-async function fetchCirculatingSupplyFromPonder(
-  environment: Environment,
-): Promise<CirculatingSupplySnapshot[]> {
-  if (!environment.indexerUrl) return [];
-  try {
-    const response = await postWithRetry<{
-      data: {
-        circulatingSupplyDailySnapshots: {
-          items: {
-            chainId: number;
-            tokenAddress: string;
-            circulatingSupply: number;
-            timestamp: number;
-          }[];
-        };
-      };
-    }>(environment.indexerUrl, {
-      query: `
-          {
-            circulatingSupplyDailySnapshots(
-              where: { chainId: ${environment.chainId} }
-              orderBy: "timestamp"
-              orderDirection: "desc"
-              limit: 1000
-            ) {
-              items {
-                chainId
-                tokenAddress
-                circulatingSupply
-                timestamp
-              }
-            }
-          }
-        `,
-    });
-
-    if (
-      response.status === 200 &&
-      response.data?.data?.circulatingSupplyDailySnapshots
-    ) {
-      return response.data.data.circulatingSupplyDailySnapshots.items.flatMap(
-        (item) => {
-          const token = Object.values(environment.config.tokens).find(
-            (t) => t.address.toLowerCase() === item.tokenAddress.toLowerCase(),
-          );
-          if (!token) return [];
-          return [
-            {
-              chainId: item.chainId,
-              token,
-              circulatingSupply: item.circulatingSupply,
-              timestamp: item.timestamp,
-            },
-          ];
-        },
-      );
-    }
-    return [];
-  } catch (ex) {
-    console.error(
-      "An error occurred while fetching getCirculatingSupplySnapshots...",
-      ex,
-    );
     return [];
   }
 }

--- a/src/actions/governance/getStakingSnapshots.test.ts
+++ b/src/actions/governance/getStakingSnapshots.test.ts
@@ -72,29 +72,13 @@ function makeClient(lunarIndexerUrl?: string): MoonwellClient {
   } as unknown as MoonwellClient;
 }
 
-const MOCK_PONDER_URL = "https://mock-ponder.test";
-
-/** Minimal MoonwellClient simulating moonriver (no lunarIndexerUrl, no indexerUrl). */
+/** Minimal MoonwellClient simulating moonriver (no lunarIndexerUrl). */
 function makeMoonriverClient(): MoonwellClient {
   return {
     environments: {
       moonriver: {
         chainId: 1285,
         lunarIndexerUrl: undefined,
-        indexerUrl: undefined,
-      } as unknown as Environment,
-    },
-  } as unknown as MoonwellClient;
-}
-
-/** Minimal MoonwellClient simulating moonriver with Ponder indexerUrl. */
-function makeMoonriverClientWithPonder(): MoonwellClient {
-  return {
-    environments: {
-      moonriver: {
-        chainId: 1285,
-        lunarIndexerUrl: undefined,
-        indexerUrl: MOCK_PONDER_URL,
       } as unknown as Environment,
     },
   } as unknown as MoonwellClient;
@@ -458,66 +442,19 @@ describe("Testing staking snapshots (unit / behavior)", () => {
   });
 });
 
-describe("Ponder path (indexerUrl, no lunarIndexerUrl)", () => {
+describe("no lunarIndexerUrl (moonriver)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  const ponderItems = [
-    {
-      chainId: 1285,
-      totalStaked: 1000,
-      totalStakedUSD: 500,
-      timestamp: 1700000000,
-    },
-    {
-      chainId: 1285,
-      totalStaked: 2000,
-      totalStakedUSD: 1000,
-      timestamp: 1700086400,
-    },
-  ];
+  test("returns [] without making any HTTP call", async () => {
+    const postSpy = vi.spyOn(axios, "post");
 
-  test("calls axios.post with indexerUrl when no lunarIndexerUrl", async () => {
-    vi.spyOn(axios, "post").mockResolvedValueOnce({
-      status: 200,
-      data: { data: { stakingDailySnapshots: { items: ponderItems } } },
-    });
-
-    const client = makeMoonriverClientWithPonder();
-    await getStakingSnapshots(client, { chainId: 1285 });
-
-    expect(vi.mocked(axios.post)).toHaveBeenCalledWith(
-      MOCK_PONDER_URL,
-      expect.objectContaining({
-        query: expect.stringContaining("chainId: 1285"),
-      }),
-    );
-    expect(createLunarIndexerClient).not.toHaveBeenCalled();
-  });
-
-  test("returns mapped snapshot data from Ponder", async () => {
-    vi.spyOn(axios, "post").mockResolvedValueOnce({
-      status: 200,
-      data: { data: { stakingDailySnapshots: { items: ponderItems } } },
-    });
-
-    const client = makeMoonriverClientWithPonder();
-    const result = await getStakingSnapshots(client, {
-      chainId: 1285,
-      period: "ALL",
-    });
-
-    expect(result).toHaveLength(2);
-    expect(result[0]?.totalStaked).toBe(1000);
-    expect(result[1]?.totalStaked).toBe(2000);
-  });
-
-  test("returns [] when both lunarIndexerUrl and indexerUrl are absent", async () => {
     const client = makeMoonriverClient();
     const result = await getStakingSnapshots(client, { chainId: 1285 });
 
     expect(result).toEqual([]);
-    expect(vi.mocked(axios.post)).not.toHaveBeenCalled();
+    expect(postSpy).not.toHaveBeenCalled();
+    expect(createLunarIndexerClient).not.toHaveBeenCalled();
   });
 });

--- a/src/actions/governance/getStakingSnapshots.ts
+++ b/src/actions/governance/getStakingSnapshots.ts
@@ -9,7 +9,6 @@ import {
 import type { NetworkParameterType } from "../../common/types.js";
 import type { Chain } from "../../environments/index.js";
 import type { StakingSnapshot } from "../../types/staking.js";
-import { postWithRetry } from "../axiosWithRetry.js";
 import {
   DEFAULT_LUNAR_TIMEOUT_MS,
   createLunarIndexerClient,
@@ -47,18 +46,7 @@ export async function getStakingSnapshots<
   } = (args ?? {}) as GetStakingSnapshotsParameters<environments, undefined>;
 
   if (!environment.lunarIndexerUrl) {
-    const { startTime } = calculateTimeRange(
-      period,
-      customStartTime,
-      customEndTime,
-    );
-    return environment.indexerUrl
-      ? fetchStakingSnapshotsFromPonder(
-          environment.chainId,
-          environment.indexerUrl,
-          startTime,
-        )
-      : [];
+    return [];
   }
 
   try {
@@ -121,50 +109,4 @@ async function fetchStakingSnapshotsFromLunar(
 
   allSnapshots.sort((a, b) => a.timestamp - b.timestamp);
   return applyGranularity(allSnapshots, granularity);
-}
-
-async function fetchStakingSnapshotsFromPonder(
-  chainId: number,
-  indexerUrl: string,
-  startTime?: number,
-): Promise<StakingSnapshot[]> {
-  try {
-    const response = await postWithRetry<{
-      data: {
-        stakingDailySnapshots: {
-          items: StakingSnapshot[];
-        };
-      };
-    }>(indexerUrl, {
-      query: `
-          query {
-            stakingDailySnapshots(
-              limit: 365,
-              orderBy: "timestamp"
-              orderDirection: "desc"
-              where: {chainId: ${chainId}}
-            ) {
-              items {
-                chainId
-                totalStaked
-                totalStakedUSD
-                timestamp
-              }
-            }
-          }
-        `,
-    });
-
-    if (response.status === 200 && response.data?.data?.stakingDailySnapshots) {
-      const items = response.data.data.stakingDailySnapshots.items;
-      return startTime
-        ? items.filter((item) => item.timestamp >= startTime)
-        : items;
-    } else {
-      return [];
-    }
-  } catch (ex) {
-    console.error("An error occured while fetching getStakingSnapshots...", ex);
-    return [];
-  }
 }

--- a/src/actions/lunar-indexer-client.ts
+++ b/src/actions/lunar-indexer-client.ts
@@ -244,7 +244,7 @@ export class LunarIndexerError extends Error {
 }
 
 /**
- * Determine if an error should trigger fallback to Ponder/on-chain
+ * Determine if an error should trigger fallback to on-chain data
  */
 export function shouldFallback(error: unknown): boolean {
   if (axios.isAxiosError(error)) {


### PR DESCRIPTION
## What

Removes the Ponder indexer fetch paths from four SDK actions:

- `getStakingSnapshots`
- `getCirculatingSupplySnapshots`
- `getMarketSnapshots` (core path)
- `getUserPositionSnapshots`

When an environment has no `lunarIndexerUrl` configured (only Moonriver), these actions now return `[]` immediately instead of querying Ponder. Net **−600 lines**.

## Why

The Ponder API (`ponder.moonwell.fi`) is decommissioned and returns HTTP 502, so these paths were dead code: every Moonriver call already failed inside a catch block and returned an empty array. Observable behavior is unchanged — the doomed network round-trip is simply gone. Lunar-indexer support for Moonriver snapshots is not planned (staking/circulating-supply were removed from the UI for Moonriver, market charts no longer render for deprecated markets, and per Luke user-position snapshots aren't needed there).

## Non-breaking by design

No public type changes. The deprecated `Environment.indexerUrl` field and the Moonriver environment's Ponder URL default are **deliberately kept** — nothing reads them anymore. Their removal is a breaking change tracked separately in [MOO-537](https://linear.app/moonwell/issue/MOO-537/remove-deprecated-indexerurl-ponder-field-from-sdk-public-types).

## Tests

Each deleted "Ponder path" suite is replaced with a behavioral test pinning the new contract: the action resolves to exactly `[]` (never `undefined`), makes no HTTP call (axios spies), and does not invoke `environment.onError` (guards against the empty result coming from the Lunar catch path instead of the intentional branch). The surviving Lunar paths and their tests are untouched.

## Reviewer notes

- `postWithRetry`/`getWithRetry` in `axiosWithRetry.ts` are kept — still used by the Snapshot-vote and Lunar circulating-supply code.
- One stale public JSDoc on `getUserPositionSnapshots` (describing the removed start-of-day filtering) was updated to match the Lunar-only behavior.
- Verified locally: lint, typecheck, all 4 test suites (156 tests), `pnpm build && pnpm test:build` (publint + attw), and the quality gate — all gated metrics hold or improve (coverage +1pp from deleting dead code). Baseline intentionally not re-captured in this PR.
- Changeset: patch bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)