### PR TITLE
MOO-587: Fix 10x-inflated Merkl staking rewards from repeated breakdown pages

### DIFF
--- a/src/actions/governance/common.ts
+++ b/src/actions/governance/common.ts
@@ -70,9 +70,23 @@ type CampaignIdsCache = {
   fetchedAt: number;
 };
 
+type MerklBreakdown =
+  MerklRewardsResponse["rewards"][number]["breakdowns"][number];
+
 const MOONWELL_MERKL_CREATOR = "0x8b621804a7637b781e2BbD58e256a591F2dF7d51";
 const CAMPAIGN_IDS_CACHE_TTL_MS = 4 * 60 * 60 * 1000; // 4 hours
 const MAX_BREAKDOWN_PAGES = 10;
+
+/**
+ * Stable identity for a Merkl reward breakdown. The Merkl `/rewards` endpoint
+ * clamps an out-of-range `breakdownPage` back to the first page instead of
+ * returning an empty page, so appending each page's breakdowns blindly
+ * re-counts the same rewards and inflates the total by the page count (up to
+ * 10x). Keying on the full breakdown content lets us skip exact repeats while
+ * still keeping genuinely distinct distributions that share a campaignId.
+ */
+const breakdownKey = (b: MerklBreakdown): string =>
+  `${b.campaignId}|${b.reason}|${b.amount}|${b.claimed}|${b.pending}|${b.subCampaignId ?? ""}`;
 
 let campaignIdsCache: CampaignIdsCache | null = null;
 
@@ -150,6 +164,14 @@ export async function getMerklRewardsData(
       return [];
     }
 
+    // Track breakdowns already collected (seeded from page 0) so repeated
+    // pages don't double-count. See breakdownKey for why Merkl repeats them.
+    const seenBreakdowns = new Set(
+      data.flatMap((reward) =>
+        reward.rewards.flatMap((r) => r.breakdowns.map(breakdownKey)),
+      ),
+    );
+
     // Paginate through remaining breakdown pages to collect all breakdowns
     for (let page = 1; page < MAX_BREAKDOWN_PAGES; page++) {
       const pageResponse = await fetch(
@@ -173,7 +195,8 @@ export async function getMerklRewardsData(
         break;
       }
 
-      // Merge breakdowns from this page into the page-0 data
+      // Merge only breakdowns we haven't collected yet.
+      let addedNewBreakdown = false;
       for (const pageReward of pageData) {
         const baseReward = data.find((d) => d.chain.id === pageReward.chain.id);
         if (!baseReward) continue;
@@ -184,10 +207,23 @@ export async function getMerklRewardsData(
               r.token.address.toLowerCase() ===
               pageRewardEntry.token.address.toLowerCase(),
           );
-          if (baseRewardEntry) {
-            baseRewardEntry.breakdowns.push(...pageRewardEntry.breakdowns);
+          if (!baseRewardEntry) continue;
+
+          for (const breakdown of pageRewardEntry.breakdowns) {
+            const key = breakdownKey(breakdown);
+            if (seenBreakdowns.has(key)) continue;
+            seenBreakdowns.add(key);
+            baseRewardEntry.breakdowns.push(breakdown);
+            addedNewBreakdown = true;
           }
         }
+      }
+
+      // A page that only repeats breakdowns we've already seen means the API
+      // has stopped advancing (out-of-range page clamped to page 0), so
+      // continuing would just re-count the same rewards.
+      if (!addedNewBreakdown) {
+        break;
       }
     }
 

--- a/src/actions/governance/getMerklRewardsData.test.ts
+++ b/src/actions/governance/getMerklRewardsData.test.ts
@@ -409,25 +409,20 @@ describe("getMerklRewardsData", () => {
   });
 
   test("stops pagination at MAX_BREAKDOWN_PAGES", async () => {
-    // Every page returns non-empty breakdowns that don't match
-    const nonMatchingPage = makeMerklResponse([
-      { campaignId: CAMPAIGN_OTHER, amount: "100", claimed: "0", pending: "0" },
-    ]);
+    // Every page returns a *distinct* non-empty, non-matching breakdown so the
+    // dedup early-stop never triggers and we exercise the hard page cap.
+    const nonMatchingPage = (amount: string) =>
+      makeMerklResponse([
+        { campaignId: CAMPAIGN_OTHER, amount, claimed: "0", pending: "0" },
+      ]);
 
-    mockFetchResponses([
-      { ok: true, data: nonMatchingPage },
-      { ok: true, data: nonMatchingPage },
-      { ok: true, data: nonMatchingPage },
-      { ok: true, data: nonMatchingPage },
-      { ok: true, data: nonMatchingPage },
-      { ok: true, data: nonMatchingPage },
-      { ok: true, data: nonMatchingPage },
-      { ok: true, data: nonMatchingPage },
-      { ok: true, data: nonMatchingPage },
-      { ok: true, data: nonMatchingPage },
-      // 11th call should never happen
-      { ok: true, data: nonMatchingPage },
-    ]);
+    mockFetchResponses(
+      // 11 pages available, but the loop must stop after fetching 10.
+      Array.from({ length: 11 }, (_, i) => ({
+        ok: true as const,
+        data: nonMatchingPage(String(100 + i)),
+      })),
+    );
 
     const result = await getMerklRewardsData(
       [CAMPAIGN_A],
@@ -438,6 +433,38 @@ describe("getMerklRewardsData", () => {
     // 1 call for page 0 + 9 calls for pages 1-9 = 10 total
     expect(fetch).toHaveBeenCalledTimes(10);
     expect(result).toHaveLength(0);
+  });
+
+  test("does not double-count breakdowns repeated on every page", async () => {
+    // Regression for MOO-587: the Merkl API clamps an out-of-range
+    // `breakdownPage` back to page 0, so it returns the *same* breakdowns on
+    // every page. Appending them blindly inflated rewards ~10x. We must count
+    // each breakdown exactly once.
+    const repeatedPage = makeMerklResponse([
+      { campaignId: CAMPAIGN_A, amount: "500", claimed: "100", pending: "0" },
+      { campaignId: CAMPAIGN_B, amount: "300", claimed: "50", pending: "0" },
+    ]);
+
+    mockFetchResponses(
+      Array.from({ length: 10 }, () => ({
+        ok: true as const,
+        data: repeatedPage,
+      })),
+    );
+
+    const result = await getMerklRewardsData(
+      [CAMPAIGN_A, CAMPAIGN_B],
+      8453,
+      "0x1234567890abcdef1234567890abcdef12345678",
+    );
+
+    // Each campaign appears exactly once, not once per page.
+    expect(result).toHaveLength(2);
+    expect(result.filter((r) => r.amount === "500")).toHaveLength(1);
+    expect(result.filter((r) => r.amount === "300")).toHaveLength(1);
+
+    // Page 0 + one repeat page detected as all-seen = 2 fetches, then stop.
+    expect(fetch).toHaveBeenCalledTimes(2);
   });
 
   test("returns empty array when fetch throws an exception", async () => {


### PR DESCRIPTION
## Summary

Staking rewards for the safety module were displayed at up to **10× their actual value** on Base (e.g. the app showed **7,648 WELL** to claim while Merkl showed **764.9 WELL** for `0x58b6920649d18b3d8162547e7ced2b3f46d7175e`).

**Root cause:** `getMerklRewardsData` paginates the Merkl `/rewards` endpoint via `breakdownPage`, appending each page's breakdowns into the page‑0 data. But Merkl **clamps an out‑of‑range `breakdownPage` back to page 0** instead of returning an empty page, so the same breakdowns were re‑appended on every page. With `MAX_BREAKDOWN_PAGES = 10`, each reward breakdown was counted up to 10 times — exactly the reported 10× inflation. `getUserStakingInfo` then sums `amount − claimed` over every (duplicated) breakdown, so the claimable total was multiplied.

I confirmed this live against the Merkl proxy for the example address: `breakdownPage=0`, `1`, and `2` all return the **same 8 breakdowns**, and the reward's top‑level `amount` equals the sum of the page‑0 breakdowns (proving page 0 is already complete).

## Fix

- Seed a `seenBreakdowns` set from page 0 and, on later pages, only append breakdowns whose content key is not already seen.
- Break out of the pagination loop as soon as a page contributes **no new** breakdowns (the clamp‑to‑page‑0 signal), which also avoids 9 redundant fetches.
- Genuinely paginated, distinct breakdowns are still merged; distributions that legitimately share a `campaignId` but differ in amount are preserved (keyed on full breakdown content).

Scoped entirely to the SDK — the frontend reads `userStakingInfo.pendingRewards.value` directly and needs no change; it picks up the fix via the SDK.

## Test evidence

- `pnpm test src/actions/governance/getMerklRewardsData.test.ts` → **29/29 passed**, including a new regression test `does not double-count breakdowns repeated on every page` and an updated `stops pagination at MAX_BREAKDOWN_PAGES`.
- `pnpm typecheck` → clean. `biome check` on changed files → clean (also enforced by the pre-commit hook).
- Full suite: the only failures are pre-existing **live-network** integration tests (`getMorphoVault`, `getUserVotingPowers`, `getBeamTokenLimits`, …) that fail with `Network Error`/`HTTP request failed` in the sandbox; I verified `getBeamTokenLimits` fails identically with my change stashed, so they are environmental and unrelated to this diff.

Fixes MOO-587

Linear: https://linear.app/moonwell/issue/MOO-587/check-morpho-campaign-for-safety-module

Prompted by: james-saint
