### PR TITLE
MOO-595: release the staking rewards fix (add missing changeset)

### DIFF
--- a/.changeset/moo-587-dedupe-merkl-reward-breakdowns.md
+++ b/.changeset/moo-587-dedupe-merkl-reward-breakdowns.md
@@ -1,0 +1,5 @@
+---
+"@moonwell-fi/moonwell-sdk": patch
+---
+
+Dedupe Merkl reward breakdowns across pages so staking rewards are no longer inflated (MOO-587). The Merkl `/rewards` endpoint clamps an out-of-range `breakdownPage` back to page 0 instead of returning an empty page, so `getMerklRewardsData` appended the same breakdowns on every page and multiplied the reported staking rewards by the page count (the app showed 7,648 WELL vs Merkl's 764.9, ~10x). `getMerklRewardsData` now seeds a seen-set from page 0 and only appends breakdowns it has not already collected, stopping as soon as a page contributes nothing new; genuinely paginated, distinct breakdowns are still merged. No public API changes.


### PR DESCRIPTION
## Summary

MOO-595 asks the frontend to consume a Moonwell SDK version that includes the staking-rewards display fix. The root blocker is upstream in this SDK repo: the fix that stops staking rewards from being inflated (~10x) — **MOO-587, "dedupe Merkl reward breakdowns across pages"** (commit 9d8a1e1) — was merged to `main` **without a changeset**. Because no changeset exists, the changesets "Version Packages" PR is never created and no new version is ever published to npm (`latest` is still `0.20.4`, which lacks the fix).

This PR adds the missing patch changeset so `@moonwell-fi/moonwell-sdk@0.20.5` gets cut with the MOO-587 fix. Once this merges → the auto-generated "Version Packages" PR merges → `0.20.5` publishes, the frontend can bump to it (that FE bump is the downstream half of MOO-595 and is blocked until `0.20.5` exists on npm).

## What the changeset releases

MOO-587 fix in `getMerklRewardsData` (`src/actions/governance/common.ts`): the Merkl `/rewards` endpoint clamps an out-of-range `breakdownPage` back to page 0 instead of returning an empty page, so breakdowns were re-appended on every page and staking rewards were multiplied by the page count (app showed 7,648 WELL vs Merkl's 764.9). The fix seeds a seen-set from page 0 and only appends breakdowns not already collected. It already ships with test coverage (`src/actions/governance/getMerklRewardsData.test.ts`).

## Test evidence

- `npx @changesets/cli status` → **`@moonwell-fi/moonwell-sdk` to be bumped at `patch`** (0.20.4 → 0.20.5). ✅
- The MOO-587 fix's own tests were added and merged with commit 9d8a1e1; this PR only adds release metadata (a `.changeset/*.md` file) and changes no source.

## Follow-up required (blocked here by token scope)

The issue also quotes a failing canary **Publish Prerelease** step. That step in `.github/workflows/changesets.yml` is genuinely broken — `changeset version` does not accept `--no-git-tag` and `changeset publish` does not accept `--snapshot` (verified against `@changesets/cli@2.31.0`), which is exactly the quoted `🦋 error Unknown flag for version: --gitTag`. (The issue's "Node 24" theory is a red herring — CI pins Node `22.x`.) This step is `continue-on-error` and only a fallback, so it does **not** block the normal `0.20.5` release, but it should be fixed:

```diff
-          pnpm changeset version --no-git-tag --snapshot canary
+          pnpm changeset version --snapshot canary
           pnpm changeset:prepublish
-          pnpm changeset publish --no-git-tag --snapshot canary --tag canary
+          pnpm changeset publish --no-git-tag --tag canary
```

I could not include this in the PR because the agent's OAuth token lacks the `workflow` scope required to push `.github/workflows/*`. A maintainer with that scope can apply the two-line diff above.

Fixes MOO-595

Linear: https://linear.app/moonwell/issue/MOO-595/bump-moonwell-sdk-version-to-include-staking-rewards-fix

Prompted by: 257466127+james-saint@users.noreply.github.com
