### PR TITLE
MOO-611: Read Moonriver proposal eta from the correct governor tuple index

### DIFF
--- a/.changeset/moo-611-moonriver-eta-tuple-index.md
+++ b/.changeset/moo-611-moonriver-eta-tuple-index.md
@@ -1,0 +1,5 @@
+---
+"@moonwell-fi/moonwell-sdk": patch
+---
+
+Read the Moonriver proposal `eta` from the correct `proposals()` tuple index (MOO-611). The legacy single-chain governor returns `(id, proposer, eta, startTimestamp, endTimestamp, ...)` so `eta` is at index 2, whereas the multichain governor returns `(proposer, voteSnapshotTimestamp, votingStartTime, votingEndTime, crossChainVoteCollectionEndTimestamp, ...)` where index 4 is the execution-available timestamp. The SDK was unconditionally reading index 4, so for legacy Moonriver proposals it picked up `endTimestamp` (the voting-end time, already in the past once voting closes). That made the frontend timeline flip straight to "Timelock Ready to Execute" and surface the Execute button before the timelock had actually elapsed. `eta` is now read from index 2 for legacy governors and index 4 for the multichain governor.

--- a/src/actions/governance/proposals/common.test.ts
+++ b/src/actions/governance/proposals/common.test.ts
@@ -812,3 +812,73 @@ describe("getProposalsOnChainData local read failure", () => {
     );
   });
 });
+
+// MOO-611: the legacy single-chain governor puts eta at tuple index 2, unlike
+// the multichain governor (index 4). See common.ts for the full bug context.
+describe("getProposalsOnChainData legacy single-chain governor eta (MOO-611)", () => {
+  const buildLegacyProposalsTuple = (eta: bigint) =>
+    [
+      0n, // id
+      "0x0000000000000000000000000000000000000001", // proposer
+      eta, // eta — legacy governor puts it at index 2
+      1_400_000_000n, // startTimestamp
+      1_500_000_000n, // endTimestamp — index 4, must NOT be read as eta
+      0n, // startBlock
+      0n, // forVotes
+      0n, // againstVotes
+      0n,
+      0n,
+      false,
+      false,
+    ] as const;
+
+  const legacyEnv = (state: bigint, proposalsTuple: unknown) =>
+    ({
+      chainId: 1285,
+      contracts: {
+        governor: {
+          read: {
+            state: vi.fn().mockResolvedValue(state),
+            proposals: vi.fn().mockResolvedValue(proposalsTuple),
+            getQuorum: vi.fn().mockResolvedValue(0n),
+            proposalCount: vi.fn().mockResolvedValue(100n),
+          },
+        },
+      },
+      custom: {},
+    }) as unknown as Parameters<typeof getProposalsOnChainData>[1];
+
+  const moonriverProposal: ApiProposal = {
+    ...baseApiProposal,
+    chainId: 1285,
+    proposalId: 42,
+    targets: [LOCAL_TARGET],
+    votingEndTime: 1_500_000_000,
+  };
+
+  test("reads eta from tuple index 2, not the index-4 endTimestamp", async () => {
+    const [data] = await getProposalsOnChainData(
+      [moonriverProposal],
+      legacyEnv(
+        BigInt(ProposalState.Queued),
+        buildLegacyProposalsTuple(1_700_000_000n),
+      ),
+    );
+
+    expect(data?.isMultichain).toBe(false);
+    expect(data?.state).toBe(ProposalState.Queued);
+    // The real timelock eta (index 2), never the voting-end endTimestamp.
+    expect(data?.eta).toBe(1_700_000_000);
+  });
+
+  test("keeps eta 0 for a legacy proposal (no multichain synthetic fallback)", async () => {
+    const [data] = await getProposalsOnChainData(
+      [moonriverProposal],
+      legacyEnv(BigInt(ProposalState.Succeeded), buildLegacyProposalsTuple(0n)),
+    );
+
+    // The votingEndTime + 1d synthesis is multichain-only; a legacy proposal
+    // that hasn't been queued yet keeps eta 0.
+    expect(data?.eta).toBe(0);
+  });
+});

--- a/src/actions/governance/proposals/common.ts
+++ b/src/actions/governance/proposals/common.ts
@@ -497,7 +497,18 @@ export const getProposalsOnChainData = async (
       let eta = 0;
 
       if (proposalData) {
-        const onChainEta = Number(proposalData[4]);
+        // The eta lives at a different tuple index per governor: the legacy
+        // single-chain governor's `proposals()` returns
+        // (id, proposer, eta, startTimestamp, endTimestamp, ...) so eta is at
+        // index 2, whereas the multichain governor's returns
+        // (proposer, voteSnapshotTimestamp, votingStartTime, votingEndTime,
+        // crossChainVoteCollectionEndTimestamp, ...) so its execution-available
+        // timestamp is at index 4. Reading index 4 for a legacy Moonriver
+        // proposal picked up `endTimestamp` (the voting-end time, already in the
+        // past once voting closes), which made the timeline flip straight to
+        // "Timelock Ready to Execute" and surfaced the Execute button before the
+        // timelock had actually elapsed (MOO-611).
+        const onChainEta = Number(proposalData[isMultichain ? 4 : 2]);
         if (onChainEta === 0 && isMultichain && p.votingEndTime) {
           eta = p.votingEndTime + 86400; // 1 day
         } else {


### PR DESCRIPTION
## Summary

On a Moonriver proposal the timeline flipped to **"Timelock Ready to Execute"** the moment voting closed and the Execute button appeared before the timelock had elapsed.

Root cause: `getProposalsOnChainData` in `common.ts` always read the timelock `eta` from `proposalData[4]`. That index is correct for the **multichain** governor (`crossChainVoteCollectionEndTimestamp`), but the **legacy single-chain** (Moonriver) governor's `proposals()` returns a differently-shaped tuple — `(id, proposer, eta, startTimestamp, endTimestamp, …)` — where `eta` is at index **2** and index 4 is `endTimestamp` (the voting-end time, already in the past once voting closes). So the SDK reported `eta = voting-end`, making `now >= eta` true immediately.

Fix: select the tuple index by governor type — `proposalData[isMultichain ? 4 : 2]`. Verified against `governorAbi.ts` (legacy) and `multichainGovernorAbi.ts` (multichain) output orderings.

The consuming button change lives in the frontend PR on the same branch (`moonwell-frontend-v2-react`).

## Test evidence

- Added `common.test.ts` cases for the legacy governor: eta is read from index 2 (not the index-4 `endTimestamp`), and a not-yet-queued legacy proposal keeps `eta = 0` (the `votingEndTime + 1d` synthesis stays multichain-only).
- `pnpm exec vitest run src/actions/governance/proposals/common.test.ts` → **54 passed**.
- Full governance suite green except `getUserVotingPowers.test.ts`, which fails only on live-RPC `HTTP request failed` (no network in CI sandbox) and is unrelated to this change.
- `tsc --noEmit` → clean. `biome check` → clean.

Fixes MOO-611

Linear: https://linear.app/moonwell/issue/MOO-611/fix-moonriver-proposal-queue-and-execute-timeline-states

Prompted by: Luke (via Linear MOO-611)